### PR TITLE
Fixing serverless-config-pack push sequence

### DIFF
--- a/installscripts/jazz-terraform-unix-noinstances/scripts/bitbucketpush.sh
+++ b/installscripts/jazz-terraform-unix-noinstances/scripts/bitbucketpush.sh
@@ -48,11 +48,11 @@ function push_to_repo() {
     individual_repo_push $1
   else
     # Initializing an array to store the order of directories to be pushed into SLF folder in SCM. "jazz-build-module" is already pushed at this stage.
-    repos=("cognito-authorizer")
+    repos=("serverless-config-pack" "cognito-authorizer")
 
     # Appending all the other repos to the array
     for d in */ ; do
-        if [[ ${d%/} != "jazz-build-module" && ${d%/} != "cognito-authorizer" ]]; then
+        if [[ ${d%/} != "jazz-build-module" && ${d%/} != "cognito-authorizer" && ${d%/} != "serverless-config-pack" ]]; then
           repos+=("${d%/}")
         fi
     done


### PR DESCRIPTION
This PR proposes to resolve the repo push sequence. 
Its now: jazz-build-module -> serverless-config-pack ->cognito-authorizer
