### PR TITLE
Installing angular-cli in jenkins cookbooks

### DIFF
--- a/installscripts/cookbooks/npm/recipes/default.rb
+++ b/installscripts/cookbooks/npm/recipes/default.rb
@@ -29,3 +29,6 @@ end
 execute 'setup permissions for symbol-observable node module' do
    command 'sudo chmod -R o+r /usr/lib/node_modules/serverless/node_modules/symbol-observable/'
 end
+execute 'install ng-cli' do
+   command 'sudo npm install -g @angular/cli'
+end


### PR DESCRIPTION
CAPI-1205: angular-cli is a requirement for UI builds