### PR TITLE
Fix usermanagement service installation

### DIFF
--- a/installscripts/jazz-terraform-unix-noinstances/scripts/modifyCodebase.sh
+++ b/installscripts/jazz-terraform-unix-noinstances/scripts/modifyCodebase.sh
@@ -31,7 +31,7 @@ do
     service_name=$element
   fi
   
-  if [ $element == "platform_email" ] || [ $element == "platform_usermanagement"] ; then		  
+  if [ $element == "platform_email" ] || [ $element == "platform_usermanagement" ] ; then		  
 	  aws dynamodb put-item --table-name $tablename --item '{
 	  "SERVICE_ID":{"S":"'$uuid'"},
 	  "SERVICE_CREATED_BY":{"S":"'$jazz_admin'"},


### PR DESCRIPTION
Usermanagement service requires v6.10. The current script has a parsing issue, where this PR fixes it.