### PR TITLE
:bug: granting users permission to pip install

### DIFF
--- a/installscripts/dockerfiles/jenkins/launch_jenkins_docker.sh
+++ b/installscripts/dockerfiles/jenkins/launch_jenkins_docker.sh
@@ -97,8 +97,8 @@ sudo docker exec -it jenkins-server /usr/bin/apt-get install python-pip -y &> /d
 spin_wheel $! "Installing python-pip in Jenkins container"
 sudo docker exec -it jenkins-server /usr/bin/pip install --upgrade pip &> /dev/null
 spin_wheel $! "Upgrading pip in Jenkins container"
-sudo docker exec -it jenkins-server /usr/bin/pip install virtualenv &> /dev/null
-spin_wheel $! "Installing virtualenv in Jenkins container"
+sudo docker exec -it jenkins-server /bin/chmod -R o+w /usr/local/lib/python2.7/dist-packages &> /dev/null
+spin_wheel $! "Granting permissions to other users to pip install"
 
 # Grab the variables
 ip=`curl -sL http://169.254.169.254/latest/meta-data/public-ipv4`


### PR DESCRIPTION
The python services creation API/Lambda is broken due to a pip permissions issue. This PR proposes to fix this. This change should be part of master once validated.