### PR TITLE
Pass in AWS creds to Terraform via environment variables

### DIFF
--- a/installscripts/chefconfig/jenkins_client.rb
+++ b/installscripts/chefconfig/jenkins_client.rb
@@ -1,2 +1,2 @@
 #root = File.absolute_path(File.dirname(__FILE__))
-cookbook_path [ '~/cookbooks', '/home/centos/cookbooks', '/root/cookbooks' ]
+cookbook_path [ '~/cookbooks' ]

--- a/installscripts/jazz-terraform-unix-noinstances/creds.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/creds.tf
@@ -1,6 +1,0 @@
-provider "aws" {
-    #This ec2-user user is of Installer box
-    shared_credentials_file  = "/home/centos/.aws/credentials"
-    profile                  = "default"
-    region = "${var.region}"
-}

--- a/installscripts/jazz-terraform-unix-noinstances/provisioners.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/provisioners.tf
@@ -22,38 +22,49 @@ resource "null_resource" "configureExistingJenkinsServer" {
   provisioner "local-exec" {
     command = "${var.configurescmelb_cmd} ${var.scmbb} ${lookup(var.scmmap, "elb")} ${var.jenkinsattribsfile} ${var.jenkinsjsonpropsfile} ${var.scmclient_cmd}"
   }
-  provisioner "file" {
-          source      = "${var.cookbooksDir}"
-          destination = "~/cookbooks"
+
+  #Because we have to provision a preexisting machine here and can't use the terraform ses command,
+  #we must use sed to insert AWS creds from the provisioner environment into a script chef will run later, before we copy the cookbook to the remote box.
+  provisioner "local-exec" {
+    command = "sed -i 's/AWS_ACCESS_KEY=.*.$/AWS_ACCESS_KEY=$AWS_ACCESS_KEY_ID/g' ${var.cookbooksDir}/jenkins/files/credentials/aws.sh"
   }
+  provisioner "local-exec" {
+    command = "sed -i 's/AWS_SECRET_KEY=.*.$/AWS_SECRET_KEY=$AWS_SECRET_ACCESS_KEY/g' ${var.cookbooksDir}/jenkins/files/credentials/aws.sh"
+  }
+
+  #Copy the chef playbooks and config over to the remote Jenkins server
   provisioner "file" {
-          source      = "${var.chefconfigDir}"
-          destination = "~/chefconfig"
+    source      = "${var.cookbooksDir}"
+    destination = "~/cookbooks"
+  }
+
+  provisioner "file" {
+    source      = "${var.chefconfigDir}"
+    destination = "~/chefconfig"
   }
 
   provisioner "remote-exec" {
-     inline = [
-           "sudo sh ~/cookbooks/installChef.sh",
-           "sudo curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /usr/local/bin/jq",
-           "sudo chmod 755 /usr/local/bin/jq",
-           "cat ~/cookbooks/jenkins/files/plugins/plugins0* > plugins.tar",
-           "sudo chmod 777 plugins.tar",
-           "sudo tar -xf plugins.tar -C /var/lib/jenkins/",
-           "sudo curl -O https://bootstrap.pypa.io/get-pip.py&& sudo python get-pip.py",
-           "sudo chmod -R o+w /usr/lib/python2.7/* /usr/bin/",
-           "sudo chef-client --local-mode -c ~/chefconfig/jenkins_client.rb -j ~/chefconfig/node-jenkinsserver-packages.json"
-     ]
-   }
-
+    inline = [
+      "sudo sh ~/cookbooks/installChef.sh",
+      "sudo curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /usr/local/bin/jq",
+      "sudo chmod 755 /usr/local/bin/jq",
+      "cat ~/cookbooks/jenkins/files/plugins/plugins0* > plugins.tar",
+      "sudo chmod 777 plugins.tar",
+      "sudo tar -xf plugins.tar -C /var/lib/jenkins/",
+      "sudo curl -O https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py",
+      "sudo chmod -R o+w /usr/lib/python2.7/* /usr/bin/",
+      "sudo chef-client --local-mode -c ~/chefconfig/jenkins_client.rb -j ~/chefconfig/node-jenkinsserver-packages.json"
+    ]
+  }
 
   provisioner "local-exec" {
-	command = "sed -i 's/\"jenkins_username\"/\"${lookup(var.jenkinsservermap, "jenkinsuser")}\"/g' ${var.jenkinsjsonpropsfile}"
+    command = "sed -i 's/\"jenkins_username\"/\"${lookup(var.jenkinsservermap, "jenkinsuser")}\"/g' ${var.jenkinsjsonpropsfile}"
   }
   provisioner "local-exec" {
     command = "${var.modifyPropertyFile_cmd} JENKINS_PASSWORD ${lookup(var.jenkinsservermap, "jenkinspasswd")} ${var.jenkinsjsonpropsfile}"
   }
   provisioner "local-exec" {
-	command = "sed -i 's/\"scm_username\"/\"${lookup(var.scmmap, "username")}\"/g' ${var.jenkinsjsonpropsfile}"
+    command = "sed -i 's/\"scm_username\"/\"${lookup(var.scmmap, "username")}\"/g' ${var.jenkinsjsonpropsfile}"
   }
   provisioner "local-exec" {
     command = "${var.modifyPropertyFile_cmd} PASSWORD ${lookup(var.scmmap, "passwd")} ${var.jenkinsjsonpropsfile}"
@@ -62,13 +73,13 @@ resource "null_resource" "configureExistingJenkinsServer" {
     command = "${var.modifyPropertyFile_cmd} ADMIN ${var.cognito_pool_username} ${var.jenkinsjsonpropsfile}"
   }
   provisioner "local-exec" {
-  command = "${var.modifyPropertyFile_cmd} PASSWD ${var.cognito_pool_password} ${var.jenkinsjsonpropsfile}"
+    command = "${var.modifyPropertyFile_cmd} PASSWD ${var.cognito_pool_password} ${var.jenkinsjsonpropsfile}"
   }
   provisioner "local-exec" {
-  command = "${var.modifyPropertyFile_cmd} ACCOUNTID ${var.jazz_accountid} ${var.jenkinsjsonpropsfile}"
+    command = "${var.modifyPropertyFile_cmd} ACCOUNTID ${var.jazz_accountid} ${var.jenkinsjsonpropsfile}"
   }
   provisioner "local-exec" {
-  command = "${var.modifyPropertyFile_cmd} REGION ${var.region} ${var.jenkinsjsonpropsfile}"
+    command = "${var.modifyPropertyFile_cmd} REGION ${var.region} ${var.jenkinsjsonpropsfile}"
   }
   // Modifying subnet replacement before copying cookbooks to Jenkins server.
   provisioner "local-exec" {
@@ -118,9 +129,9 @@ resource "null_resource" "configureExistingJenkinsServer" {
     destination = "~/chefconfig"
   }
 
- provisioner "remote-exec" {
+  provisioner "remote-exec" {
     inline = [
-          "sudo chef-client --local-mode -c ~/chefconfig/jenkins_client.rb --override-runlist blankJenkins::configureblankjenkins"
+      "sudo chef-client --local-mode -c ~/chefconfig/jenkins_client.rb --override-runlist blankJenkins::configureblankjenkins"
     ]
   }
 
@@ -157,28 +168,28 @@ resource "null_resource" "copyJazzBuildModule" {
 
 // Configure jazz-installer-vars.json and push it to SLF/jazz-build-module
 resource "null_resource" "configureJazzBuildModule" {
- depends_on = ["null_resource.copyJazzBuildModule"]
+  depends_on = ["null_resource.copyJazzBuildModule"]
 
- connection {
-   host = "${lookup(var.jenkinsservermap, "jenkins_public_ip")}"
-   user = "${lookup(var.jenkinsservermap, "jenkins_ssh_login")}"
-   port = "${lookup(var.jenkinsservermap, "jenkins_ssh_port")}"
-   type = "ssh"
-   port = "${lookup(var.jenkinsservermap, "jenkins_ssh_port")}"
-   private_key = "${file("${lookup(var.jenkinsservermap, "jenkins_ssh_key")}")}"
- }
- provisioner "remote-exec"{
-   inline = [
-       "git clone http://${lookup(var.scmmap, "username")}:${lookup(var.scmmap, "passwd")}@${lookup(var.scmmap, "elb")}${lookup(var.scmmap, "scmPathExt")}/slf/jazz-build-module.git",
-       "cd jazz-build-module",
-       "cp ~/cookbooks/jenkins/files/node/jazz-installer-vars.json .",
-       "git add jazz-installer-vars.json",
-       "git config --global user.email ${var.cognito_pool_username}",
-       "git commit -m 'Adding Json file to repo'",
-       "git push -u origin master",
-       "cd ..",
-       "sudo rm -rf jazz-build-module" ]
- }  
+  connection {
+    host = "${lookup(var.jenkinsservermap, "jenkins_public_ip")}"
+    user = "${lookup(var.jenkinsservermap, "jenkins_ssh_login")}"
+    port = "${lookup(var.jenkinsservermap, "jenkins_ssh_port")}"
+    type = "ssh"
+    port = "${lookup(var.jenkinsservermap, "jenkins_ssh_port")}"
+    private_key = "${file("${lookup(var.jenkinsservermap, "jenkins_ssh_key")}")}"
+  }
+  provisioner "remote-exec"{
+    inline = [
+      "git clone http://${lookup(var.scmmap, "username")}:${lookup(var.scmmap, "passwd")}@${lookup(var.scmmap, "elb")}${lookup(var.scmmap, "scmPathExt")}/slf/jazz-build-module.git",
+      "cd jazz-build-module",
+      "cp ~/cookbooks/jenkins/files/node/jazz-installer-vars.json .",
+      "git add jazz-installer-vars.json",
+      "git config --global user.email ${var.cognito_pool_username}",
+      "git commit -m 'Adding Json file to repo'",
+      "git push -u origin master",
+      "cd ..",
+      "sudo rm -rf jazz-build-module" ]
+  }  
 }
 
 // Push all other repos to SLF

--- a/installscripts/jazz-terraform-unix-noinstances/scripts/create.sh
+++ b/installscripts/jazz-terraform-unix-noinstances/scripts/create.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
-aws_secret_access_key=`tr -d '\n' < ~/.aws/credentials | sed -e 's/\[/\n[/g'|grep default|sed -e 's/\[default\]//g' -e 's/aws_secret_access_key/\naws_secret_access_key/g' -e  's/ //g' |grep aws_secret_access_key| cut -d'=' -f2`
-aws_access_key=`tr -d '\n' < ~/.aws/credentials | sed -e 's/\[/\n[/g'|grep default|sed -e 's/\[default\]//g' -e 's/aws_secret_access_key/\naws_secret_access_key/g' -e  's/ //g'| grep "aws_access_key" |cut -d'=' -f2`
-sed -i "s/AWS_ACCESS_KEY=.*.$/AWS_ACCESS_KEY=$aws_access_key/g" ../cookbooks/jenkins/files/credentials/aws.sh
-sed -i "s|AWS_SECRET_KEY=.*.$|AWS_SECRET_KEY=$aws_secret_access_key|g" ../cookbooks/jenkins/files/credentials/aws.sh
 rm -f ./settings.txt
 date
-terraform apply
+terraform apply \
+          -var 'aws_access_key=$AWS_ACCESS_KEY_ID' \
+          -var 'aws_secret_key=$AWS_SECRET_ACCESS_KEY' \
+          -var 'region=$AWS_DEFAULT_REGION'
 date
 echo " ======================================================="
 echo " The following stack has been created in AWS"

--- a/installscripts/jazz-terraform-unix-noinstances/scripts/ses.sh
+++ b/installscripts/jazz-terraform-unix-noinstances/scripts/ses.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+#TODO Verify if this script actually needs AWS credentials to be passed in, or if we can
+#do the appropriate AWS commands via the TF AWS module
 EMAIL_ADDRESS=$1
 REGION=$2
 JENKINSATTRIBSFILE=$3

--- a/installscripts/wizard/jazz_common.py
+++ b/installscripts/wizard/jazz_common.py
@@ -16,24 +16,15 @@ def parse_and_replace_paramter_list(terraform_folder, parameter_list):
         are replaced in variables.tf and other files needed
     """
     jazz_branch = parameter_list[0]
-    aws_credentials = parameter_list[1]
-    aws_region = parameter_list[2]
-    cognito_details = parameter_list[3]
-    jazz_account_id = parameter_list[4]
-    jazz_tag_details = parameter_list[5] #[tag_env_prefix, tag_enviornment, tag_exempt, tag_owner]
+    cognito_details = parameter_list[1]
+    jazz_account_id = parameter_list[2]
+    jazz_tag_details = parameter_list[3] #[tag_env_prefix, tag_enviornment, tag_exempt, tag_owner]
 
     os.chdir(terraform_folder)
 
     # ----------------------------------------------------------
     # Populate variables in terraform variables.tf and cookbooks
     # -----------------------------------------------------------
-    # Populating AWS Accesskey and
-    subprocess.call(['sed', '-i', "s|variable \"aws_access_key\".*.$|variable \"aws_access_key\" \{ type = \"string\" default = \"%s\" \}|g" %(aws_credentials[0]), VARIABLES_TF_FILE])
-    subprocess.call(['sed', '-i', "s|variable \"aws_secret_key\".*.$|variable \"aws_secret_key\" \{ type = \"string\" default = \"%s\" \}|g" %(aws_credentials[1]), VARIABLES_TF_FILE])
-
-    # Populating AWS Region
-    subprocess.call(['sed', '-i', "s|variable \"region\".*.$|variable \"region\" \{ type = \"string\" default = \"%s\" \}|g" %(aws_region), VARIABLES_TF_FILE])
-    subprocess.call(['sed', '-i', "s|variable \"github_branch\".*.$|variable \"github_branch\" \{ type = \"string\" default = \"%s\" \}|g" %(jazz_branch), VARIABLES_TF_FILE])
 
     #populating BRANCH name
     subprocess.call(['sed', '-i', "s|variable \"github_branch\".*.$|variable \"github_branch\" \{ type = \"string\" default = \"%s\" \}|g" %(jazz_branch), VARIABLES_TF_FILE])

--- a/installscripts/wizard/jazz_generic_details.py
+++ b/installscripts/wizard/jazz_generic_details.py
@@ -32,8 +32,6 @@ def get_aws_credentials():
     if "AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY" not in os.environ:
         os.environ['AWS_ACCESS_KEY_ID'] = raw_input("AWS Access Key ID :")
         os.environ['AWS_SECRET_ACCESS_KEY'] = raw_input("AWS Secret Access Key :")
-    #TODO drop this return value once we remove the thing that depends on these values being returned.
-    return [os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY']]
 
 def set_aws_config(region):
     """
@@ -64,7 +62,7 @@ def get_stack_generic_details(jazz_branch):
     print("Please provide the details to setup Jazz")
 
     region = None
-    knownWorkingRegions = ['us-east-1', 'us-east-2', 'us-west-2']
+    knownWorkingRegions = ['us-east-1', 'us-west-2']
 
     region = raw_input("AWS Region (e.g. us-east-1): ")
     if region not in knownWorkingRegions:
@@ -98,6 +96,6 @@ def get_stack_generic_details(jazz_branch):
     jazz_account_id = jazz_account_id[:-1]
 
     # Determine the scenario
-    parameter_list = [jazz_branch, aws_credentials, region, [cognito_email_id, cognito_passwd], jazz_account_id, jazz_tag_details]
+    parameter_list = [jazz_branch, [cognito_email_id, cognito_passwd], jazz_account_id, jazz_tag_details]
 
     return parameter_list

--- a/installscripts/wizard/jazz_generic_details.py
+++ b/installscripts/wizard/jazz_generic_details.py
@@ -93,7 +93,6 @@ def get_stack_generic_details(jazz_branch):
     region = raw_input("AWS Region (e.g. us-east-1): ")
     if region not in knownWorkingRegions:
         print 'Warning: This installer has not been tested against the region you specified.\nPlease check the Jazz documentation to verify the region you have chosen supports the required AWS resources.'
-        break
 
     # Get the aws credentials
     aws_credentials = get_aws_credentials()

--- a/installscripts/wizard/jazz_generic_details.py
+++ b/installscripts/wizard/jazz_generic_details.py
@@ -84,7 +84,7 @@ def get_jazz_tag_config_details():
 
 def get_stack_generic_details(jazz_branch):
     
-    print ""
+    print("")
     print("Please provide the details to setup Jazz")
 
     region = None
@@ -92,12 +92,12 @@ def get_stack_generic_details(jazz_branch):
  
     region = raw_input("AWS Region (e.g. us-east-1): ")
     if region not in knownWorkingRegions:
-        print 'Warning: This installer has not been tested against the region you specified.\nPlease check the Jazz documentation to verify the region you have chosen supports the required AWS resources.'
+        print('Warning: This installer has not been tested against the region you specified.\nPlease check the Jazz documentation (https://github.com/tmobile/jazz-installer/wiki#prerequisites) to verify the region you have chosen supports the required AWS resources.')
 
     # Get the aws credentials
     aws_credentials = get_aws_credentials()
     while aws_credentials[0] == '' or aws_credentials[1] == '':
-        print "Please provide the AWS credentials"
+        print("Please provide the AWS credentials")
         aws_credentials = get_aws_credentials()
 
     write_aws_credential_to_file(aws_credentials[0], aws_credentials[1])
@@ -112,7 +112,7 @@ def get_stack_generic_details(jazz_branch):
         if validate_email_id(cognito_email_id):
             break
         else:
-            print "The email address is invalid."
+            print("The email address is invalid.")
     cognito_passwd = passwd_generator()
 
     jazz_account_id = ""
@@ -122,7 +122,7 @@ def get_stack_generic_details(jazz_branch):
         jazz_account_id = subprocess.check_output(jazz_accountid_cmd)
 
     except:
-        print "Unable to get caller identity. Are you sure the credentials are correct? Please retry..."
+        print("Unable to get caller identity. Are you sure the credentials are correct? Please retry...")
         exit(0)
     jazz_account_id = jazz_account_id[:-1]
 

--- a/installscripts/wizard/jazz_generic_details.py
+++ b/installscripts/wizard/jazz_generic_details.py
@@ -25,45 +25,22 @@ def passwd_generator():
     random.shuffle(pwd)
     return ''.join(pwd)
 
-
 def get_aws_credentials():
     """
-        Get the aws credentials from user
+        If the AWS credentials have not already been defined as env vars, populate those env vars
     """
-    aws_access_key = raw_input("AWS Access Key ID :")
-    aws_secret_key = raw_input("AWS Secret Access Key :")
-    return [aws_access_key, aws_secret_key]
+    if "AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY" not in os.environ:
+        os.environ['AWS_ACCESS_KEY_ID'] = raw_input("AWS Access Key ID :")
+        os.environ['AWS_SECRET_ACCESS_KEY'] = raw_input("AWS Secret Access Key :")
+    #TODO drop this return value once we remove the thing that depends on these values being returned.
+    return [os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY']]
 
-def write_aws_credential_to_file(aws_access_key, aws_secret_key):
-    """
-        Writing the aws credential ~/aws/credentials file
-    """
-    home = os.path.expanduser("~")
-    aws_folder = home + "/.aws"
-    aws_credential_file = aws_folder + "/credentials"
-
-    if not os.path.isdir(aws_folder):
-        os.makedirs(aws_folder)
-
-    #write to the file
-    fd = open(aws_credential_file, "w")
-    fd.write("[default]\n")
-    fd.write("aws_access_key_id = " + aws_access_key + "\n")
-    fd.write("aws_secret_access_key = " + aws_secret_key + "\n")
-
-def write_aws_config_to_file(region):
+def set_aws_config(region):
     """
         Writing the aws credential ~/aws/config file
     """
-    home = os.path.expanduser("~")
-    aws_folder = home + "/.aws"
-    aws_config_file = aws_folder + "/config"
-
-    #write to the file
-    fd = open(aws_config_file, "w")
-    fd.write("[default]\n")
-    fd.write("output = json\n")
-    fd.write("region = " + region + "\n")
+    os.environ['AWS_DEFAULT_OUTPUT'] = 'json'
+    os.environ['AWS_DEFAULT_REGION'] = region
 
 def get_jazz_tag_config_details():
     """
@@ -83,25 +60,19 @@ def get_jazz_tag_config_details():
     return [tag_env_prefix, tag_enviornment, tag_exempt, tag_owner]
 
 def get_stack_generic_details(jazz_branch):
-    
     print("")
     print("Please provide the details to setup Jazz")
 
     region = None
     knownWorkingRegions = ['us-east-1', 'us-east-2', 'us-west-2']
- 
+
     region = raw_input("AWS Region (e.g. us-east-1): ")
     if region not in knownWorkingRegions:
         print('Warning: This installer has not been tested against the region you specified.\nPlease check the Jazz documentation (https://github.com/tmobile/jazz-installer/wiki#prerequisites) to verify the region you have chosen supports the required AWS resources.')
 
-    # Get the aws credentials
+    # Get the aws credentials & set required AWS env vars
     aws_credentials = get_aws_credentials()
-    while aws_credentials[0] == '' or aws_credentials[1] == '':
-        print("Please provide the AWS credentials")
-        aws_credentials = get_aws_credentials()
-
-    write_aws_credential_to_file(aws_credentials[0], aws_credentials[1])
-    write_aws_config_to_file(region)
+    set_aws_config(region)
 
     # get Jazz Tag details
     jazz_tag_details = get_jazz_tag_config_details()

--- a/installscripts/wizard/jazz_scenarios.py
+++ b/installscripts/wizard/jazz_scenarios.py
@@ -16,7 +16,7 @@ def is_valid_scenario(option):
 def print_stack_options():
     for key, value in OPTIONS.iteritems():
         option_string = value[0]
-        print option_string
+        print(option_string)
 
 def execute(key, git_branch_name):
     if not is_valid_scenario(key):

--- a/installscripts/wizard/run.py
+++ b/installscripts/wizard/run.py
@@ -27,7 +27,7 @@ def main():
                 print("Invalid selection! Try again\n")
 
     except KeyboardInterrupt:
-        print "\nKeyboard Interrupt detected exiting.."
+        print("\nKeyboard Interrupt detected exiting..")
 
 #Entry Point
 main()


### PR DESCRIPTION
This is step 1 of the move towards making Terraform the top-level setup tool (issue #110), so that 

- We can take advantage of Terraform functionality like automatic retries

- People can run the Terraform script from their local laptop, and Terraform can create a staging/docker host instance automatically, rather than us requiring people to manually stand up a CentOS staging box beforehand.

- Provide an install method that sysadmins are already comfortable using

- Drive all configuration via Terraform, so our CLI and (maybe eventually) GUI installers do nothing but collect and populate Terraform variables.

This PR does the following:
- Remove python code that clobbers/creates a `.aws/credentials` file and instead set AWS credentials and region via environment variables. Terraform will pick up on these for its own connection to AWS, and can pass down the environment variables as Terraform variables. 

  - Note that this will reuse the values in the standard AWS env vars if they are already set before the script runs. This means you can reuse existing credentials, and you will not be asked repeatedly for the same AWS credentials on each run of the installer. 

  - This also reduces the coupling between the Python CLI and the Terraform scripts (which will be useful later).

- Rather than reach over into the Chef cookbook to run `sed` on the Jenkins setup script from the Python CLI, do it from Terraform (which is what actually invokes Chef).

