### PR TITLE
:bug: Fixing the /dev/tty redirection issue & jazz-core clone issue

### DIFF
--- a/installscripts/Installer.sh
+++ b/installscripts/Installer.sh
@@ -149,8 +149,8 @@ function install_packages () {
   spin_wheel $! "Downloading and installing paramiko"
 
   #Undo output redirection
-  exec 1>/dev/tty
-  exec 2>/dev/tty
+  exec 1> /dev/stdout
+  exec 2> /dev/stderr
 }
 
 function post_installation () {

--- a/installscripts/jazz-terraform-unix-noinstances/s3bucket.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/s3bucket.tf
@@ -118,6 +118,10 @@ resource "aws_api_gateway_rest_api" "jazz-stag" {
 resource "aws_api_gateway_rest_api" "jazz-prod" {
   name        = "${var.envPrefix}-prod"
   description = "PROD API"
+  
+  provisioner "local-exec" {
+    command = "rm -rf jazz-core"
+  }
   provisioner "local-exec" {
     command = "git clone -b ${var.github_branch} https://github.com/tmobile/jazz.git jazz-core"
 


### PR DESCRIPTION
Redirection of file descriptors to /dev/tty resulted in the following error in jenkins job execution. 
`/dev/tty: No such device or address`. 

This PR proposes to fix this issue by manually redirecting the file descriptors to stdout and stderr instead of /dev/tty.

