### PR TITLE
Restoring cookbook_path location

### DIFF
--- a/installscripts/chefconfig/jenkins_client.rb
+++ b/installscripts/chefconfig/jenkins_client.rb
@@ -1,2 +1,4 @@
 #root = File.absolute_path(File.dirname(__FILE__))
-cookbook_path [ '~/cookbooks' ]
+# Scenario 1 expects cookbook location at /home/centos/cookbooks
+# Scenarios 2 & 3 expects cookbook location at /root/cookbooks
+cookbook_path [ '~/cookbooks', '/home/centos/cookbooks', '/root/cookbooks' ]


### PR DESCRIPTION
The cookbook paths were removed in earlier merges to v1.4.1. This started reporting the following error is chef execution:
`INFO: HTTP Request Returned 404 Not Found: Object not found:
resolving cookbooks for run list: ["git", "maven", "npm", "aws", "blankJenkins"]
INFO: HTTP Request Returned 412 Precondition Failed: No such cookbook: git`

Restoring the cookbook paths.