### PR TITLE
Don't hardcode AWS path. Let system resolve it.

### DIFF
--- a/installscripts/wizard/jazz_generic_details.py
+++ b/installscripts/wizard/jazz_generic_details.py
@@ -86,7 +86,7 @@ def get_stack_generic_details(jazz_branch):
 
     jazz_account_id = ""
     try:
-        jazz_accountid_cmd = ['/usr/local/bin/aws', 'sts', 'get-caller-identity', '--output', 'text', '--query',
+        jazz_accountid_cmd = ['aws', 'sts', 'get-caller-identity', '--output', 'text', '--query',
                               'Account']
         jazz_account_id = subprocess.check_output(jazz_accountid_cmd)
 


### PR DESCRIPTION
Now that we're installing `aws` with `pip` it's not in `/usr/local/bin` anymore, so install script was failing. We shouldn't hardcode the full path to the executable anyway, since it always should be in $PATH if we install via `pip`.

Without this fix, install on a clean CentOS box definitely breaks for me. Was the CI failing?