### PR TITLE
Dynamic AWS API Ids

### DIFF
--- a/installscripts/cookbooks/jenkins/files/node/jazz-installer-vars.json
+++ b/installscripts/cookbooks/jenkins/files/node/jazz-installer-vars.json
@@ -19,7 +19,18 @@
 	"API": {
     "DEV_ID": "",
     "STG_ID": "",
-    "PROD_ID": ""
+    "PROD_ID": "",
+    "PROD": {
+      "*": "{AWS_PROD_API_ID_DEFAULT}",
+      "jazz_*": "{AWS_PROD_API_ID_JAZZ}"
+    },
+    "STG": {
+      "*": "{AWS_STG_API_ID_DEFAULT}",
+      "jazz_*": "{AWS_STG_API_ID_JAZZ}"
+    },
+    "DEV": {
+      "*": "{AWS_DEV_API_ID_DEFAULT}"
+    }
   },
     
 	"S3": {

--- a/installscripts/jazz-terraform-unix-noinstances/scripts/configureApikey.sh
+++ b/installscripts/jazz-terraform-unix-noinstances/scripts/configureApikey.sh
@@ -7,9 +7,11 @@ jenkinsjsonpropsfile=$5
 jenkinsattribsfile=$6
 env_name_prefix=$7
 
-sed -i "s/DEV_ID\".*.$/DEV_ID\": \"$DEV_ID\",/g" $jenkinsjsonpropsfile
-sed -i "s/STG_ID\".*.$/STG_ID\": \"$STG_ID\",/g" $jenkinsjsonpropsfile
-sed -i "s/PROD_ID\".*.$/PROD_ID\": \"$PROD_ID\"/g" $jenkinsjsonpropsfile
+sed -i "s/{AWS_DEV_API_ID_DEFAULT}/$DEV_ID/g" $jenkinsjsonpropsfile
+sed -i "s/{AWS_STG_API_ID_DEFAULT}/$STG_ID/g" $jenkinsjsonpropsfile
+sed -i "s/{AWS_STG_API_ID_JAZZ}/$STG_ID/g" $jenkinsjsonpropsfile
+sed -i "s/{AWS_PROD_API_ID_JAZZ}/$PROD_ID/g" $jenkinsjsonpropsfile
+sed -i "s/{AWS_PROD_API_ID_DEFAULT}/$PROD_ID/g" $jenkinsjsonpropsfile
 sed -i "s/INSTANCE_PREFIX\".*.$/INSTANCE_PREFIX\": \"$env_name_prefix\",/g" $jenkinsjsonpropsfile
 
 # Changing jazz-web config.json


### PR DESCRIPTION
### Requirements
* Jazz platform should allow users to create APIs beyond 300 resources (AWS Limit)
* Segregate Jazz platform API's from user APIs
* Allow Jazz Admins/Users choose **namespace** specific API endpoints
* Allow Jazz Admins/Users to choose **service** specific API endpoints

### Description of the Change

* [API Gateway Limits](https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html) have limited Jazz customers from creating API endpoints. Specifically the "Resources Per API" limit of 300 limits the capability of Jazz to be used as a platform.
* Jazz Admins can specify a general bucket, per namespace, per service specific API endpoints through the configuration file. These specifications are applied for PROD, STG and DEV categories.
* By default one endpoint is created for each of PROD, STG and DEV categories. 

### Benefits

* Jazz platform will allow users to create APIs beyond 300 resources (AWS Limit)
* Jazz Admins can choose to segregate Jazz platform API's from user APIs
* Jazz Admins can choose **namespace** specific API endpoints
* Jazz Admins can choose **service** specific API endpoints

### Possible Drawbacks

* Jazz Admins have to apply the changes though a JSON config file