### PR TITLE
Fix bug with destroy script

### DIFF
--- a/installscripts/jazz-terraform-unix-noinstances/scripts/DeleteStackPlatformServices.py
+++ b/installscripts/jazz-terraform-unix-noinstances/scripts/DeleteStackPlatformServices.py
@@ -41,7 +41,7 @@ deleteClientServices = sys.argv[2]
 platformServices = ['jazz-cognito-authorizer', 'jazz-logs', 'jazz-usermanagement', 'jazz-services-handler', 'jazz-events', 'jazz-services', 'jazz-logout', 'jazz-login', 'jazz-cloud-logs-streamer', 'jazz-is-service-available', 'jazz-delete-serverless-service', 'jazz-create-serverless-service', 'jazz-email', 'jazz-events-handler', 'jazz-environments', 'jazz-scm-webhook' , 'jazz-environment-event-handler']
 
 for pservice in platformServices:
-    deleteCloudFormationService(stackName + pservice)
+    deleteCloudFormationService(stackName + pservice + '-prod')
 
 print ("\r\n\r\nCompleted deletion of platform services.")
 

--- a/installscripts/jazz-terraform-unix-noinstances/scripts/DeleteStackPlatformServices.py
+++ b/installscripts/jazz-terraform-unix-noinstances/scripts/DeleteStackPlatformServices.py
@@ -21,11 +21,11 @@ def deleteCloudFormationService(service_name):
         print ("Service::" + service_name + ": exists. Service deletion started.........")
         delete_return_code = deleteCFService(service_name)
         if delete_return_code == 0 :
-            print ("\tSuccessfully Deleted service " + service_name)
+            print ("\tSuccessfully deleted service " + service_name)
         else :
-            print ("\tError while Deleting service " + service_name + " errorcode=" + delete_return_code)
+            print ("\tError while deleting service " + service_name + " errorcode=" + delete_return_code)
     else:
-        print ('Error Service not found::' + service_name)
+        print ('Error service not found::' + service_name)
 
 
 if(len(sys.argv) != 3):
@@ -38,17 +38,17 @@ print (str(sys.argv))
 stackName = sys.argv[1].lower() + "-"
 deleteClientServices = sys.argv[2]
 
-platformServices = ['jazz_cognito-authorizer', 'jazz_logs', 'jazz_usermanagement', 'jazz_services-handler', 'jazz_events', 'jazz_services', 'jazz_logout', 'jazz_login', 'jazz_cloud-logs-streamer', 'jazz_is-service-available', 'jazz_delete-serverless-service', 'jazz_create-serverless-service', 'jazz_email', 'jazz_events-handler', 'jazz_environments', 'jazz_scm-webhook' , 'jazz_environment-event-handler']
+platformServices = ['jazz-cognito-authorizer', 'jazz-logs', 'jazz-usermanagement', 'jazz-services-handler', 'jazz-events', 'jazz-services', 'jazz-logout', 'jazz-login', 'jazz-cloud-logs-streamer', 'jazz-is-service-available', 'jazz-delete-serverless-service', 'jazz-create-serverless-service', 'jazz-email', 'jazz-events-handler', 'jazz-environments', 'jazz-scm-webhook' , 'jazz-environment-event-handler']
 
 for pservice in platformServices:
     deleteCloudFormationService(stackName + pservice)
 
-print ("\r\n\r\nCompleted Deletion Platform services.")
+print ("\r\n\r\nCompleted deletion of platform services.")
 
 if (deleteClientServices.lower() != 'true'):
     exit(0)
 
-print ("\r\nStarting deletions of Client Services\r\n\r\n")
+print ("\r\nStarting deletion of client services\r\n\r\n")
 
 ## Delete user services Cloud formations 
 fname = 'listservice.json'

--- a/installscripts/jazz-terraform-unix-noinstances/scripts/destroy.sh
+++ b/installscripts/jazz-terraform-unix-noinstances/scripts/destroy.sh
@@ -2,19 +2,22 @@
 date
 
 stack_name=""
-currentDir=`pwd`
 loopIndx=0
 
 if [ "$1" == "" ]; then
-     echo "Please provide Argument [all or frameworkonly]"
+     echo "Please provide argument [all or frameworkonly]"
      exit 1
 fi
 
 echo "parameter::$1"
 
 if [ "$1" != "all" ] && [ "$1" != "frameworkonly" ]; then
-     echo "Please provide Argument [all or frameworkonly]"
+     echo "Please provide argument [all or frameworkonly]"
      exit 1
+fi
+
+if [ -z "$JAZZ_INSTALLER_ROOT" ]; then
+    export $JAZZ_INSTALLER_ROOT=`pwd`
 fi
 
 # Rename any stack_deletion out files if any
@@ -36,7 +39,7 @@ echo " ======================================================="
 
 echo " Destroying of stack initiated!!! "
 echo " Execute  'tail -f stack_deletion_X.out' in below directory to see the stack deletion progress (X=1 or 2 or 3)"
-echo $currentDir
+echo $JAZZ_INSTALLER_ROOT 
 
 echo " ======================================================="
 


### PR DESCRIPTION
Fix bug(s) with destroy script:
1. Incorrectly identifies cloudformation templates for core services
2. Expects $JAZZ_INSTALLER_ROOT to be set 