### PR TITLE
Changed apache-maven from mirror downloadable link

### DIFF
--- a/installscripts/cookbooks/maven/recipes/default.rb
+++ b/installscripts/cookbooks/maven/recipes/default.rb
@@ -1,5 +1,5 @@
 remote_file '/tmp/apache-maven-3.5.2-bin.tar.gz' do
-  source 'http://mirror.olnevhost.net/pub/apache/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz'
+  source 'https://archive.apache.org/dist/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz'
   mode '0755'
   action :create
 end
@@ -14,5 +14,3 @@ end
 execute 'createsymlink' do
   command 'sudo ln -sf /opt/apache-maven-3.5.2/bin/mvn /usr/bin/mvn'
 end
-
-


### PR DESCRIPTION
Previous link is getting 404 - http://mirror.olnevhost.net/pub/apache/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz
Changed to stable publication link.