### PR TITLE
Adding api targets to create service component during jazz installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 node_modules
 .DS_Store
 .vscode/
+/.idea
 */.classpath
 */.project
 */.settings

--- a/installscripts/cookbooks/jenkins/files/node/jazz-installer-vars.json
+++ b/installscripts/cookbooks/jenkins/files/node/jazz-installer-vars.json
@@ -75,7 +75,9 @@
     },
     "UI_CONFIG": {
         "CREATE_SERVICE": {
-            "DEPLOYMENT_TARGETS": true
+            "API_DEPLOYMENT_TARGETS": true,
+            "FUNCTION_DEPLOYMENT_TARGETS": false,
+            "WEBSITE_DEPLOYMENT_TARGETS": false
         },
         "feature": {
             "multi_env": true

--- a/installscripts/cookbooks/jenkins/files/node/jazz-installer-vars.json
+++ b/installscripts/cookbooks/jenkins/files/node/jazz-installer-vars.json
@@ -2,103 +2,104 @@
   "AWS_CREDENTIAL_ID": "awscreds1",
   "INSTANCE_PREFIX": "",
   "AWS": {
-  	"SECURITY_GROUP_IDS": "",
-  	"SUBNET_IDS": "",
-  	"LAMBDA_EXECUTION_ROLE": "",
-	"CLOUDFRONT_ORIGIN_ID": "",
-	"ACCOUNTID": "",
-	"REGION": "",
-	"ROLEID": "",
-	"ES_HOSTNAME": "",
-	"COGNITO": {
-      		"USER_POOL_ID": "",
-      		"CLIENT_ID": ""
-  	},
-  	"API": {
-    		"PROD": {
-      			"*": "{AWS_PROD_API_ID_DEFAULT}",
-			"jazz_*": "{AWS_PROD_API_ID_JAZZ}"
-    		},
-    		"STG": {
-      			"*": "{AWS_STG_API_ID_DEFAULT}",
-      			"jazz_*": "{AWS_STG_API_ID_JAZZ}"
-    		},
-    		"DEV": {
-      			"*": "{AWS_DEV_API_ID_DEFAULT}"
-    		}
-  	},
-	"S3": {
-	   	"API_DOC": "",
-		"DEV_BUCKET": "",
-		"STG_BUCKET": "",
-		"PROD_BUCKET": ""  
-	}
+    "SECURITY_GROUP_IDS": "",
+    "SUBNET_IDS": "",
+    "LAMBDA_EXECUTION_ROLE": "",
+    "CLOUDFRONT_ORIGIN_ID": "",
+    "ACCOUNTID": "",
+    "REGION": "",
+    "ROLEID": "",
+    "ES_HOSTNAME": "",
+    "COGNITO": {
+      "USER_POOL_ID": "",
+      "CLIENT_ID": ""
+    },
+    "API": {
+      "PROD": {
+        "*": "{AWS_PROD_API_ID_DEFAULT}",
+        "jazz_*": "{AWS_PROD_API_ID_JAZZ}"
+      },
+      "STG": {
+        "*": "{AWS_STG_API_ID_DEFAULT}",
+        "jazz_*": "{AWS_STG_API_ID_JAZZ}"
+      },
+      "DEV": {
+        "*": "{AWS_DEV_API_ID_DEFAULT}"
+      }
+    },
+    "S3": {
+      "API_DOC": "",
+      "DEV_BUCKET": "",
+      "STG_BUCKET": "",
+      "PROD_BUCKET": ""
+    }
   },
   "REPOSITORY": {
-    	"BASE_URL": "",
-    	"CREDENTIAL_ID": "jenkins1cred",
-    	"REPO_BASE_SERVICES": "cas",
-    	"REPO_BASE_PLATFORM" : "slf"
+    "BASE_URL": "",
+    "CREDENTIAL_ID": "jenkins1cred",
+    "REPO_BASE_SERVICES": "cas",
+    "REPO_BASE_PLATFORM": "slf"
   },
   "API": {
-    	"API_BUILD_URI": "/job/build_pack_api/buildWithParameters?token=slf-java-api-build-101"
+    "API_BUILD_URI": "/job/build_pack_api/buildWithParameters?token=slf-java-api-build-101"
   },
   "LAMBDA": {
-    	"LAMBDA_BUILD_URI": "/job/build-pack-lambda/buildWithParameters?token=slf-lambda-build-101"
+    "LAMBDA_BUILD_URI": "/job/build-pack-lambda/buildWithParameters?token=slf-lambda-build-101"
   },
   "WEBSITE": {
-    	"WEBSITE_BUILD_URI": "/job/build-pack-website/buildWithParameters?token=slf-website-build-0907"
+    "WEBSITE_BUILD_URI": "/job/build-pack-website/buildWithParameters?token=slf-website-build-0907"
   },
   "JAZZ": {
-    	"ADMIN": "",
-    	"PASSWD": "",
-    	"S3_BUCKET_NAME_SUFFIX": "_BUCKET",
-    	"S3_BUCKET_WEB": "",
-        "BUCKET_PER_SERVICE": "false",
-    	"S3": {     
-       		"WEBSITE_DEV_BUCKET": "",
-       		"WEBSITE_STG_BUCKET": "",
-       		"WEBSITE_PROD_BUCKET": ""
-    	}
+    "ADMIN": "",
+    "PASSWD": "",
+    "S3_BUCKET_NAME_SUFFIX": "_BUCKET",
+    "S3_BUCKET_WEB": "",
+    "BUCKET_PER_SERVICE": "false",
+    "S3": {
+      "WEBSITE_DEV_BUCKET": "",
+      "WEBSITE_STG_BUCKET": "",
+      "WEBSITE_PROD_BUCKET": ""
+    }
   },
   "JENKINS": {
-    	"USERNAME": "jenkins_username",
-    	"JENKINS_PASSWORD": "",
-    	"CREDENTIAL_ID": "jobexecutor"
+    "USERNAME": "jenkins_username",
+    "JENKINS_PASSWORD": "",
+    "CREDENTIAL_ID": "jobexecutor"
   },
   "SCM": {
-    	"TYPE": "bitbucket",
-    	"PRIVATE_TOKEN": "",
-    	"CAS_NAMESPACE_ID": "",
-    	"USERNAME": "scm_username",
-    	"PASSWORD": ""
-   },
-   "UI_CONFIG": { 
-		 "feature": {
-			 "multi_env": true
-		 },
-		 "service_tabs":
-		 {
-			 "overview": true,
-			 "access_control": false,
-			 "metrics": false,
-			 "logs": true,
-			 "cost": false
-		 },
-		 "environment_tabs":
-		 {
-			 "overview": true,
-			 "deployments": true,
-			 "code_quality": false,
-			 "logs": false,
-			 "assets": false
-		 }
-   },
-    "APIGEE": {
-        "API_ENDPOINTS": {
-            "PROD": "{APIGEE_PROD_API}",
-            "STG": "{APIGEE_STG_API}",
-            "DEV": "{APIGEE_DEV_API}"
-        }
+    "TYPE": "bitbucket",
+    "PRIVATE_TOKEN": "",
+    "CAS_NAMESPACE_ID": "",
+    "USERNAME": "scm_username",
+    "PASSWORD": ""
+  },
+  "UI_CONFIG": {
+    "CREATE_SERVICE": {
+      "DEPLOYMENT_TARGETS": true
+    },
+    "feature": {
+      "multi_env": true
+    },
+    "service_tabs": {
+      "overview": true,
+      "access_control": false,
+      "metrics": false,
+      "logs": true,
+      "cost": false
+    },
+    "environment_tabs": {
+      "overview": true,
+      "deployments": true,
+      "code_quality": false,
+      "logs": false,
+      "assets": false
     }
+  },
+  "APIGEE": {
+    "API_ENDPOINTS": {
+      "PROD": "{APIGEE_PROD_API}",
+      "STG": "{APIGEE_STG_API}",
+      "DEV": "{APIGEE_DEV_API}"
+    }
+  }
 }

--- a/installscripts/cookbooks/jenkins/files/node/jazz-installer-vars.json
+++ b/installscripts/cookbooks/jenkins/files/node/jazz-installer-vars.json
@@ -1,105 +1,105 @@
 {
-  "AWS_CREDENTIAL_ID": "awscreds1",
-  "INSTANCE_PREFIX": "",
-  "AWS": {
-    "SECURITY_GROUP_IDS": "",
-    "SUBNET_IDS": "",
-    "LAMBDA_EXECUTION_ROLE": "",
-    "CLOUDFRONT_ORIGIN_ID": "",
-    "ACCOUNTID": "",
-    "REGION": "",
-    "ROLEID": "",
-    "ES_HOSTNAME": "",
-    "COGNITO": {
-      "USER_POOL_ID": "",
-      "CLIENT_ID": ""
+    "AWS_CREDENTIAL_ID": "awscreds1",
+    "INSTANCE_PREFIX": "",
+    "AWS": {
+        "SECURITY_GROUP_IDS": "",
+        "SUBNET_IDS": "",
+        "LAMBDA_EXECUTION_ROLE": "",
+        "CLOUDFRONT_ORIGIN_ID": "",
+        "ACCOUNTID": "",
+        "REGION": "",
+        "ROLEID": "",
+        "ES_HOSTNAME": "",
+        "COGNITO": {
+            "USER_POOL_ID": "",
+            "CLIENT_ID": ""
+        },
+        "API": {
+            "PROD": {
+                "*": "{AWS_PROD_API_ID_DEFAULT}",
+                "jazz_*": "{AWS_PROD_API_ID_JAZZ}"
+            },
+            "STG": {
+                "*": "{AWS_STG_API_ID_DEFAULT}",
+                "jazz_*": "{AWS_STG_API_ID_JAZZ}"
+            },
+            "DEV": {
+                "*": "{AWS_DEV_API_ID_DEFAULT}"
+            }
+        },
+        "S3": {
+            "API_DOC": "",
+            "DEV_BUCKET": "",
+            "STG_BUCKET": "",
+            "PROD_BUCKET": ""
+        }
+    },
+    "REPOSITORY": {
+        "BASE_URL": "",
+        "CREDENTIAL_ID": "jenkins1cred",
+        "REPO_BASE_SERVICES": "cas",
+        "REPO_BASE_PLATFORM": "slf"
     },
     "API": {
-      "PROD": {
-        "*": "{AWS_PROD_API_ID_DEFAULT}",
-        "jazz_*": "{AWS_PROD_API_ID_JAZZ}"
-      },
-      "STG": {
-        "*": "{AWS_STG_API_ID_DEFAULT}",
-        "jazz_*": "{AWS_STG_API_ID_JAZZ}"
-      },
-      "DEV": {
-        "*": "{AWS_DEV_API_ID_DEFAULT}"
-      }
+        "API_BUILD_URI": "/job/build_pack_api/buildWithParameters?token=slf-java-api-build-101"
     },
-    "S3": {
-      "API_DOC": "",
-      "DEV_BUCKET": "",
-      "STG_BUCKET": "",
-      "PROD_BUCKET": ""
-    }
-  },
-  "REPOSITORY": {
-    "BASE_URL": "",
-    "CREDENTIAL_ID": "jenkins1cred",
-    "REPO_BASE_SERVICES": "cas",
-    "REPO_BASE_PLATFORM": "slf"
-  },
-  "API": {
-    "API_BUILD_URI": "/job/build_pack_api/buildWithParameters?token=slf-java-api-build-101"
-  },
-  "LAMBDA": {
-    "LAMBDA_BUILD_URI": "/job/build-pack-lambda/buildWithParameters?token=slf-lambda-build-101"
-  },
-  "WEBSITE": {
-    "WEBSITE_BUILD_URI": "/job/build-pack-website/buildWithParameters?token=slf-website-build-0907"
-  },
-  "JAZZ": {
-    "ADMIN": "",
-    "PASSWD": "",
-    "S3_BUCKET_NAME_SUFFIX": "_BUCKET",
-    "S3_BUCKET_WEB": "",
-    "BUCKET_PER_SERVICE": "false",
-    "S3": {
-      "WEBSITE_DEV_BUCKET": "",
-      "WEBSITE_STG_BUCKET": "",
-      "WEBSITE_PROD_BUCKET": ""
-    }
-  },
-  "JENKINS": {
-    "USERNAME": "jenkins_username",
-    "JENKINS_PASSWORD": "",
-    "CREDENTIAL_ID": "jobexecutor"
-  },
-  "SCM": {
-    "TYPE": "bitbucket",
-    "PRIVATE_TOKEN": "",
-    "CAS_NAMESPACE_ID": "",
-    "USERNAME": "scm_username",
-    "PASSWORD": ""
-  },
-  "UI_CONFIG": {
-    "CREATE_SERVICE": {
-      "DEPLOYMENT_TARGETS": true
+    "LAMBDA": {
+        "LAMBDA_BUILD_URI": "/job/build-pack-lambda/buildWithParameters?token=slf-lambda-build-101"
     },
-    "feature": {
-      "multi_env": true
+    "WEBSITE": {
+        "WEBSITE_BUILD_URI": "/job/build-pack-website/buildWithParameters?token=slf-website-build-0907"
     },
-    "service_tabs": {
-      "overview": true,
-      "access_control": false,
-      "metrics": false,
-      "logs": true,
-      "cost": false
+    "JAZZ": {
+        "ADMIN": "",
+        "PASSWD": "",
+        "S3_BUCKET_NAME_SUFFIX": "_BUCKET",
+        "S3_BUCKET_WEB": "",
+        "BUCKET_PER_SERVICE": "false",
+        "S3": {
+            "WEBSITE_DEV_BUCKET": "",
+            "WEBSITE_STG_BUCKET": "",
+            "WEBSITE_PROD_BUCKET": ""
+        }
     },
-    "environment_tabs": {
-      "overview": true,
-      "deployments": true,
-      "code_quality": false,
-      "logs": false,
-      "assets": false
+    "JENKINS": {
+        "USERNAME": "jenkins_username",
+        "JENKINS_PASSWORD": "",
+        "CREDENTIAL_ID": "jobexecutor"
+    },
+    "SCM": {
+        "TYPE": "bitbucket",
+        "PRIVATE_TOKEN": "",
+        "CAS_NAMESPACE_ID": "",
+        "USERNAME": "scm_username",
+        "PASSWORD": ""
+    },
+    "UI_CONFIG": {
+        "CREATE_SERVICE": {
+            "DEPLOYMENT_TARGETS": true
+        },
+        "feature": {
+            "multi_env": true
+        },
+        "service_tabs": {
+            "overview": true,
+            "access_control": false,
+            "metrics": false,
+            "logs": true,
+            "cost": false
+        },
+        "environment_tabs": {
+            "overview": true,
+            "deployments": true,
+            "code_quality": false,
+            "logs": false,
+            "assets": false
+        }
+    },
+    "APIGEE": {
+        "API_ENDPOINTS": {
+            "PROD": "{APIGEE_PROD_API}",
+            "STG": "{APIGEE_STG_API}",
+            "DEV": "{APIGEE_DEV_API}"
+        }
     }
-  },
-  "APIGEE": {
-    "API_ENDPOINTS": {
-      "PROD": "{APIGEE_PROD_API}",
-      "STG": "{APIGEE_STG_API}",
-      "DEV": "{APIGEE_DEV_API}"
-    }
-  }
 }


### PR DESCRIPTION
adds new category of installer vars in UI_CONFIG section
CREATE_SERVICE: {
    DEPLOYMENT_TARGETS: Boolean
}
enables apigee deployment targets

(also replaced tabs with spaces)