### PR TITLE
Enable tagging of AWS resources

### DIFF
--- a/Installer.sh
+++ b/Installer.sh
@@ -20,6 +20,7 @@ LOG_FILE_NAME=installer_setup.out
 LOG_FILE=`realpath $INSTALL_DIR/$LOG_FILE_NAME`
 JAZZ_BRANCH="master"
 CODE_QUALITY='false'
+AWS_TAGS=''
 
 function start_wizard {
     # Set the permissions
@@ -29,7 +30,7 @@ function start_wizard {
     # Call the python script to continue installation process
     cd $INSTALL_DIR/installscripts/wizard
 
-    python ./run.py $JAZZ_BRANCH $INSTALL_DIR $CODE_QUALITY
+    python ./run.py $JAZZ_BRANCH $INSTALL_DIR $CODE_QUALITY "$AWS_TAGS"
 
     setterm -term linux -fore green
     setterm -term linux -fore default
@@ -76,11 +77,11 @@ while [ $# -gt 0 ] ; do
             shift
             while [ "$#" -gt 0 ] ; do
                 if [[ "$1" =~ Key=.*,Value=.* ]] && [[ ! "$1" =~ ";" ]] ; then
-                    arr+=("$1")
+                    AWS_TAGS="$AWS_TAGS $1"
                 elif [[ $1 == -* ]] ; then break
                 else
-                    echo "Please specify tags in format: Key=stackName,Value=production"
-                    echo "Usage: ./Installer --tags Key=stackName,Value=production Key=department,Value=devops"
+                    echo "Please specify tags in format: Key=stackname,Value=production"
+                    echo "Usage: ./Installer --tags Key=stackname,Value=production Key=department,Value=devops"
                     exit 1
                 fi
                 shift

--- a/installscripts/cookbooks/jenkins/files/default/jazz-installer-vars.json
+++ b/installscripts/cookbooks/jenkins/files/default/jazz-installer-vars.json
@@ -32,7 +32,8 @@
             "DEV_BUCKET": "",
             "STG_BUCKET": "",
             "PROD_BUCKET": ""
-        }
+        },
+        "TAGS": []
     },
     "REPOSITORY": {
         "BASE_URL": "",
@@ -112,7 +113,4 @@
         "SLACK_WORKSPACE": "{slack_workspace}",
         "SLACK_SVC_ID": "{slack_svc_acc_id}"
     }
-        "SLACK_TOKEN": "{slack_token}"
-    },
-    "AWS_TAGS": []
 }

--- a/installscripts/cookbooks/jenkins/files/default/jazz-installer-vars.json
+++ b/installscripts/cookbooks/jenkins/files/default/jazz-installer-vars.json
@@ -112,4 +112,7 @@
         "SLACK_WORKSPACE": "{slack_workspace}",
         "SLACK_SVC_ID": "{slack_svc_acc_id}"
     }
+        "SLACK_TOKEN": "{slack_token}"
+    },
+    "AWS_TAGS": []
 }

--- a/installscripts/jazz-terraform-unix-noinstances/cloudfront.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/cloudfront.tf
@@ -39,12 +39,8 @@ resource "aws_cloudfront_distribution" "jazz" {
 
   price_class = "PriceClass_All"
 
-  tags = "${merge(var.additional_tags, map(
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "production"
-          ))}"
-  
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
   custom_error_response{
     error_caching_min_ttl = "300"
     error_code = "404"

--- a/installscripts/jazz-terraform-unix-noinstances/cloudfront.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/cloudfront.tf
@@ -39,13 +39,12 @@ resource "aws_cloudfront_distribution" "jazz" {
 
   price_class = "PriceClass_All"
 
-
-  tags {
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "production"
-  }
-
+  tags = "${merge(var.additional_tags, map(
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "production"
+          ))}"
+  
   custom_error_response{
     error_caching_min_ttl = "300"
     error_code = "404"

--- a/installscripts/jazz-terraform-unix-noinstances/dynamodb.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/dynamodb.tf
@@ -9,14 +9,7 @@ resource "aws_dynamodb_table" "dynamodb-table-dev" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
 }
 
 resource "aws_dynamodb_table" "dynamodb-table-stg" {
@@ -30,14 +23,7 @@ resource "aws_dynamodb_table" "dynamodb-table-stg" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
 }
 
 resource "aws_dynamodb_table" "dynamodb-table-prod" {
@@ -51,14 +37,7 @@ resource "aws_dynamodb_table" "dynamodb-table-prod" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
 }
 
 resource "aws_dynamodb_table" "dynamodb-table_Event_Handler_Dev" {
@@ -72,14 +51,7 @@ resource "aws_dynamodb_table" "dynamodb-table_Event_Handler_Dev" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
 
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_HANDLER ${var.envPrefix}_Event_Handler_Dev"
@@ -97,14 +69,8 @@ resource "aws_dynamodb_table" "dynamodb-table_Event_Handler_Stg" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_HANDLER ${var.envPrefix}_Event_Handler_Stg"
   }
@@ -121,14 +87,8 @@ resource "aws_dynamodb_table" "dynamodb-table_Event_Handler_Prod" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_HANDLER ${var.envPrefix}_Event_Handler_Prod"
   }
@@ -145,14 +105,8 @@ resource "aws_dynamodb_table" "dynamodb-Event_Name_Dev" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_NAME ${var.envPrefix}_Event_Name_Dev"
   }
@@ -169,14 +123,8 @@ resource "aws_dynamodb_table" "dynamodb-Event_Name_Stg" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_NAME ${var.envPrefix}_Event_Name_Stg"
   }
@@ -193,14 +141,8 @@ resource "aws_dynamodb_table" "dynamodb-Event_Name_Prod" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_NAME ${var.envPrefix}_Event_Name_Prod"
   }
@@ -217,14 +159,8 @@ resource "aws_dynamodb_table" "dynamodb-Event_Status_Dev" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_STATUS ${var.envPrefix}_Event_Status_Dev"
   }
@@ -241,14 +177,8 @@ resource "aws_dynamodb_table" "dynamodb-Event_Status_Stg" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_STATUS ${var.envPrefix}_Event_Status_Stg"
   }
@@ -265,14 +195,8 @@ resource "aws_dynamodb_table" "dynamodb-Event_Status_Prod" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_STATUS ${var.envPrefix}_Event_Status_Prod"
   }
@@ -289,14 +213,8 @@ resource "aws_dynamodb_table" "dynamodb-Event_Type_Dev" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_TYPE ${var.envPrefix}_Event_Type_Dev"
   }
@@ -313,14 +231,8 @@ resource "aws_dynamodb_table" "dynamodb-Event_Type_Stg" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_TYPE ${var.envPrefix}_Event_Type_Stg"
   }
@@ -337,14 +249,8 @@ resource "aws_dynamodb_table" "dynamodb-Event_Type_Prod" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_TYPE ${var.envPrefix}_Event_Type_Prod"
   }
@@ -361,14 +267,8 @@ resource "aws_dynamodb_table" "dynamodb-Events_Dev" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
 }
 
 resource "aws_dynamodb_table" "dynamodb-Events_Stg" {
@@ -382,14 +282,8 @@ resource "aws_dynamodb_table" "dynamodb-Events_Stg" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
 }
 
 resource "aws_dynamodb_table" "dynamodb-Events_Prod" {
@@ -403,14 +297,8 @@ resource "aws_dynamodb_table" "dynamodb-Events_Prod" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
 }
 
 resource "aws_dynamodb_table" "dynamodb-Environments_Dev" {
@@ -443,14 +331,8 @@ resource "aws_dynamodb_table" "dynamodb-Environments_Dev" {
     projection_type    = "ALL"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
 }
 
 resource "aws_dynamodb_table" "dynamodb-Environments_Stg" {
@@ -483,14 +365,8 @@ resource "aws_dynamodb_table" "dynamodb-Environments_Stg" {
     projection_type    = "ALL"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
 }
 
 resource "aws_dynamodb_table" "dynamodb-Environments_Prod" {
@@ -523,14 +399,8 @@ resource "aws_dynamodb_table" "dynamodb-Environments_Prod" {
     projection_type    = "ALL"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
 }
 
 resource "aws_dynamodb_table" "dynamodb-Deployments_Dev" {
@@ -544,14 +414,8 @@ resource "aws_dynamodb_table" "dynamodb-Deployments_Dev" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
 }
 
 resource "aws_dynamodb_table" "dynamodb-Deployments_Stg" {
@@ -565,14 +429,8 @@ resource "aws_dynamodb_table" "dynamodb-Deployments_Stg" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
 }
 
 resource "aws_dynamodb_table" "dynamodb-Deployments_Prod" {
@@ -586,14 +444,8 @@ resource "aws_dynamodb_table" "dynamodb-Deployments_Prod" {
     type = "S"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
 }
 
 resource "aws_dynamodb_table" "dynamodb-Assets_Dev" {
@@ -626,14 +478,8 @@ resource "aws_dynamodb_table" "dynamodb-Assets_Dev" {
     projection_type    = "ALL"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
 }
 
 resource "aws_dynamodb_table" "dynamodb-Assets_Stg" {
@@ -666,14 +512,8 @@ resource "aws_dynamodb_table" "dynamodb-Assets_Stg" {
     projection_type    = "ALL"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
 }
 
 resource "aws_dynamodb_table" "dynamodb-Assets_Prod" {
@@ -706,12 +546,6 @@ resource "aws_dynamodb_table" "dynamodb-Assets_Prod" {
     projection_type    = "ALL"
   }
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
 }

--- a/installscripts/jazz-terraform-unix-noinstances/dynamodb.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/dynamodb.tf
@@ -9,14 +9,14 @@ resource "aws_dynamodb_table" "dynamodb-table-dev" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 }
 
 resource "aws_dynamodb_table" "dynamodb-table-stg" {
@@ -30,14 +30,14 @@ resource "aws_dynamodb_table" "dynamodb-table-stg" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 }
 
 resource "aws_dynamodb_table" "dynamodb-table-prod" {
@@ -51,14 +51,14 @@ resource "aws_dynamodb_table" "dynamodb-table-prod" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 }
 
 resource "aws_dynamodb_table" "dynamodb-table_Event_Handler_Dev" {
@@ -72,14 +72,14 @@ resource "aws_dynamodb_table" "dynamodb-table_Event_Handler_Dev" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_HANDLER ${var.envPrefix}_Event_Handler_Dev"
@@ -97,14 +97,14 @@ resource "aws_dynamodb_table" "dynamodb-table_Event_Handler_Stg" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_HANDLER ${var.envPrefix}_Event_Handler_Stg"
   }
@@ -121,14 +121,14 @@ resource "aws_dynamodb_table" "dynamodb-table_Event_Handler_Prod" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_HANDLER ${var.envPrefix}_Event_Handler_Prod"
   }
@@ -145,15 +145,14 @@ resource "aws_dynamodb_table" "dynamodb-Event_Name_Dev" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_NAME ${var.envPrefix}_Event_Name_Dev"
   }
@@ -170,14 +169,14 @@ resource "aws_dynamodb_table" "dynamodb-Event_Name_Stg" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_NAME ${var.envPrefix}_Event_Name_Stg"
   }
@@ -194,14 +193,14 @@ resource "aws_dynamodb_table" "dynamodb-Event_Name_Prod" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_NAME ${var.envPrefix}_Event_Name_Prod"
   }
@@ -218,14 +217,14 @@ resource "aws_dynamodb_table" "dynamodb-Event_Status_Dev" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_STATUS ${var.envPrefix}_Event_Status_Dev"
   }
@@ -242,14 +241,14 @@ resource "aws_dynamodb_table" "dynamodb-Event_Status_Stg" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_STATUS ${var.envPrefix}_Event_Status_Stg"
   }
@@ -266,14 +265,14 @@ resource "aws_dynamodb_table" "dynamodb-Event_Status_Prod" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_STATUS ${var.envPrefix}_Event_Status_Prod"
   }
@@ -290,14 +289,14 @@ resource "aws_dynamodb_table" "dynamodb-Event_Type_Dev" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_TYPE ${var.envPrefix}_Event_Type_Dev"
   }
@@ -314,14 +313,14 @@ resource "aws_dynamodb_table" "dynamodb-Event_Type_Stg" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_TYPE ${var.envPrefix}_Event_Type_Stg"
   }
@@ -338,14 +337,14 @@ resource "aws_dynamodb_table" "dynamodb-Event_Type_Prod" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
   provisioner "local-exec" {
     command = "${var.dynamodb_cmd} EVENT_TYPE ${var.envPrefix}_Event_Type_Prod"
   }
@@ -362,14 +361,14 @@ resource "aws_dynamodb_table" "dynamodb-Events_Dev" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 }
 
 resource "aws_dynamodb_table" "dynamodb-Events_Stg" {
@@ -383,14 +382,14 @@ resource "aws_dynamodb_table" "dynamodb-Events_Stg" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 }
 
 resource "aws_dynamodb_table" "dynamodb-Events_Prod" {
@@ -404,14 +403,14 @@ resource "aws_dynamodb_table" "dynamodb-Events_Prod" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 }
 
 resource "aws_dynamodb_table" "dynamodb-Environments_Dev" {
@@ -444,14 +443,14 @@ resource "aws_dynamodb_table" "dynamodb-Environments_Dev" {
     projection_type    = "ALL"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 }
 
 resource "aws_dynamodb_table" "dynamodb-Environments_Stg" {
@@ -484,14 +483,14 @@ resource "aws_dynamodb_table" "dynamodb-Environments_Stg" {
     projection_type    = "ALL"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 }
 
 resource "aws_dynamodb_table" "dynamodb-Environments_Prod" {
@@ -524,14 +523,14 @@ resource "aws_dynamodb_table" "dynamodb-Environments_Prod" {
     projection_type    = "ALL"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 }
 
 resource "aws_dynamodb_table" "dynamodb-Deployments_Dev" {
@@ -545,14 +544,14 @@ resource "aws_dynamodb_table" "dynamodb-Deployments_Dev" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 }
 
 resource "aws_dynamodb_table" "dynamodb-Deployments_Stg" {
@@ -566,14 +565,14 @@ resource "aws_dynamodb_table" "dynamodb-Deployments_Stg" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 }
 
 resource "aws_dynamodb_table" "dynamodb-Deployments_Prod" {
@@ -587,14 +586,14 @@ resource "aws_dynamodb_table" "dynamodb-Deployments_Prod" {
     type = "S"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 }
 
 resource "aws_dynamodb_table" "dynamodb-Assets_Dev" {
@@ -627,14 +626,14 @@ resource "aws_dynamodb_table" "dynamodb-Assets_Dev" {
     projection_type    = "ALL"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 }
 
 resource "aws_dynamodb_table" "dynamodb-Assets_Stg" {
@@ -667,14 +666,14 @@ resource "aws_dynamodb_table" "dynamodb-Assets_Stg" {
     projection_type    = "ALL"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 }
 
 resource "aws_dynamodb_table" "dynamodb-Assets_Prod" {
@@ -707,12 +706,12 @@ resource "aws_dynamodb_table" "dynamodb-Assets_Prod" {
     projection_type    = "ALL"
   }
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 }

--- a/installscripts/jazz-terraform-unix-noinstances/elasticsearch.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/elasticsearch.tf
@@ -12,11 +12,11 @@ resource "aws_elasticsearch_domain" "elasticsearch_domain" {
     volume_type = "gp2"
     volume_size = 10
   }
-  tags = "${merge(var.additional_tags, map(
+
+  tags = "${merge(var.additional_tags, local.common_tags, map(
           "Domain", "${var.envPrefix}_elasticsearch_domain",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
           ))}"
+          
   //vpc_options {
   //  security_group_ids = ["${lookup(var.jenkinsservermap, "jenkins_security_group")}"],
   //  subnet_ids = ["${lookup(var.jenkinsservermap, "jenkins_subnet")}"]

--- a/installscripts/jazz-terraform-unix-noinstances/elasticsearch.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/elasticsearch.tf
@@ -12,12 +12,11 @@ resource "aws_elasticsearch_domain" "elasticsearch_domain" {
     volume_type = "gp2"
     volume_size = 10
   }
-
-  tags {
-    Domain = "${var.envPrefix}_elasticsearch_domain"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Domain", "${var.envPrefix}_elasticsearch_domain",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          ))}"
   //vpc_options {
   //  security_group_ids = ["${lookup(var.jenkinsservermap, "jenkins_security_group")}"],
   //  subnet_ids = ["${lookup(var.jenkinsservermap, "jenkins_subnet")}"]

--- a/installscripts/jazz-terraform-unix-noinstances/jenkins.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/jenkins.tf
@@ -84,7 +84,7 @@ resource "null_resource" "update_jenkins_configs" {
     command = "${var.modifyPropertyFile_cmd} REGION ${var.region} ${var.jenkinsjsonpropsfile}"
   }
   provisioner "local-exec" {
-    command = "${var.modifyPropertyFile_cmd} AWS_TAGS \"${var.aws_tags}\" ${var.jenkinsjsonpropsfile} 'nostring'"
+    command = "${var.modifyPropertyFile_cmd} TAGS \"${var.aws_tags}\" ${var.jenkinsjsonpropsfile} 'nostring'"
   }
   // Modifying subnet replacement before copying cookbooks to Jenkins server.
   provisioner "local-exec" {

--- a/installscripts/jazz-terraform-unix-noinstances/jenkins.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/jenkins.tf
@@ -83,6 +83,9 @@ resource "null_resource" "update_jenkins_configs" {
   provisioner "local-exec" {
     command = "${var.modifyPropertyFile_cmd} REGION ${var.region} ${var.jenkinsjsonpropsfile}"
   }
+  provisioner "local-exec" {
+    command = "${var.modifyPropertyFile_cmd} AWS_TAGS \"${var.aws_tags}\" ${var.jenkinsjsonpropsfile} 'nostring'"
+  }
   // Modifying subnet replacement before copying cookbooks to Jenkins server.
   provisioner "local-exec" {
     command = "${var.configureSubnet_cmd} ${lookup(var.jenkinsservermap, "jenkins_security_group")} ${lookup(var.jenkinsservermap, "jenkins_subnet")} ${var.envPrefix} ${var.jenkinsjsonpropsfile}"

--- a/installscripts/jazz-terraform-unix-noinstances/kinesis.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/kinesis.tf
@@ -8,14 +8,7 @@ resource "aws_kinesis_stream" "kinesis_stream_dev" {
     "OutgoingBytes",
   ]
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
 }
 
 resource "aws_kinesis_stream" "kinesis_stream_stg" {
@@ -28,14 +21,7 @@ resource "aws_kinesis_stream" "kinesis_stream_stg" {
     "OutgoingBytes",
   ]
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
 }
 
 resource "aws_kinesis_stream" "kinesis_stream_prod" {
@@ -48,12 +34,5 @@ resource "aws_kinesis_stream" "kinesis_stream_prod" {
     "OutgoingBytes",
   ]
 
-  tags = "${merge(var.additional_tags, map(
-          "Name", "${var.envPrefix}",
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          "Environment", "${var.tagsEnvironment}",
-          "Exempt", "${var.tagsExempt}",
-          "Owner", "${var.tagsOwner}"
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
 }

--- a/installscripts/jazz-terraform-unix-noinstances/kinesis.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/kinesis.tf
@@ -8,14 +8,14 @@ resource "aws_kinesis_stream" "kinesis_stream_dev" {
     "OutgoingBytes",
   ]
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 }
 
 resource "aws_kinesis_stream" "kinesis_stream_stg" {
@@ -28,14 +28,14 @@ resource "aws_kinesis_stream" "kinesis_stream_stg" {
     "OutgoingBytes",
   ]
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 }
 
 resource "aws_kinesis_stream" "kinesis_stream_prod" {
@@ -48,12 +48,12 @@ resource "aws_kinesis_stream" "kinesis_stream_prod" {
     "OutgoingBytes",
   ]
 
-  tags {
-    Name        = "${var.envPrefix}"
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-    Environment = "${var.tagsEnvironment}"
-    Exempt = "${var.tagsExempt}"
-    Owner = "${var.tagsOwner}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Name", "${var.envPrefix}",
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          "Environment", "${var.tagsEnvironment}",
+          "Exempt", "${var.tagsExempt}",
+          "Owner", "${var.tagsOwner}"
+          ))}"
 }

--- a/installscripts/jazz-terraform-unix-noinstances/s3bucket.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/s3bucket.tf
@@ -10,10 +10,10 @@ resource "aws_s3_bucket" "oab-apis-deployment-dev" {
     allowed_origins = ["*"]
     max_age_seconds = 3000
   }
-  tags {
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          ))}"
 
   provisioner "local-exec" {
     command = "${var.sets3acl_cmd} ${aws_s3_bucket.oab-apis-deployment-dev.bucket} ${data.aws_canonical_user_id.current.id}"
@@ -35,10 +35,10 @@ resource "aws_s3_bucket" "oab-apis-deployment-stg" {
     allowed_origins = ["*"]
     max_age_seconds = 3000
   }
-  tags {
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          ))}"
   provisioner "local-exec" {
     command = "${var.sets3acl_cmd} ${aws_s3_bucket.oab-apis-deployment-stg.bucket} ${data.aws_canonical_user_id.current.id}"
   }
@@ -59,10 +59,10 @@ resource "aws_s3_bucket" "oab-apis-deployment-prod" {
     allowed_origins = ["*"]
     max_age_seconds = 3000
   }
-  tags {
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          ))}"
   provisioner "local-exec" {
     command = "${var.sets3acl_cmd} ${aws_s3_bucket.oab-apis-deployment-prod.bucket} ${data.aws_canonical_user_id.current.id}"
   }
@@ -86,10 +86,10 @@ resource "aws_s3_bucket" "jazz_s3_api_doc" {
     allowed_origins = ["*"]
     max_age_seconds = 3000
   }
-  tags {
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          ))}"
   website {
     index_document = "index.html"
   }
@@ -136,10 +136,10 @@ resource "aws_s3_bucket" "jazz-web" {
     allowed_origins = ["*"]
     max_age_seconds = 3000
   }
-  tags {
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          ))}"
   website {
     index_document = "index.html"
 
@@ -310,10 +310,10 @@ resource "aws_s3_bucket" "dev-serverless-static" {
     allowed_origins = ["*"]
     max_age_seconds = 3000
   }
-  tags {
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          ))}"
   provisioner "local-exec" {
     when = "destroy"
     on_failure = "continue"
@@ -332,10 +332,10 @@ resource "aws_s3_bucket" "stg-serverless-static" {
     allowed_origins = ["*"]
     max_age_seconds = 3000
   }
-  tags {
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          ))}"
   provisioner "local-exec" {
     when = "destroy"
     on_failure = "continue"
@@ -354,10 +354,10 @@ resource "aws_s3_bucket" "prod-serverless-static" {
     allowed_origins = ["*"]
     max_age_seconds = 3000
   }
-  tags {
-    Application = "Jazz"
-    JazzInstance = "${var.envPrefix}"
-  }
+  tags = "${merge(var.additional_tags, map(
+          "Application", "Jazz",
+          "JazzInstance", "${var.envPrefix}",
+          ))}"
 
   # TODO do we need this, or does `force_destroy` suffice?
   provisioner "local-exec" {

--- a/installscripts/jazz-terraform-unix-noinstances/s3bucket.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/s3bucket.tf
@@ -10,10 +10,7 @@ resource "aws_s3_bucket" "oab-apis-deployment-dev" {
     allowed_origins = ["*"]
     max_age_seconds = 3000
   }
-  tags = "${merge(var.additional_tags, map(
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
 
   provisioner "local-exec" {
     command = "${var.sets3acl_cmd} ${aws_s3_bucket.oab-apis-deployment-dev.bucket} ${data.aws_canonical_user_id.current.id}"
@@ -35,10 +32,8 @@ resource "aws_s3_bucket" "oab-apis-deployment-stg" {
     allowed_origins = ["*"]
     max_age_seconds = 3000
   }
-  tags = "${merge(var.additional_tags, map(
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
   provisioner "local-exec" {
     command = "${var.sets3acl_cmd} ${aws_s3_bucket.oab-apis-deployment-stg.bucket} ${data.aws_canonical_user_id.current.id}"
   }
@@ -59,10 +54,8 @@ resource "aws_s3_bucket" "oab-apis-deployment-prod" {
     allowed_origins = ["*"]
     max_age_seconds = 3000
   }
-  tags = "${merge(var.additional_tags, map(
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
   provisioner "local-exec" {
     command = "${var.sets3acl_cmd} ${aws_s3_bucket.oab-apis-deployment-prod.bucket} ${data.aws_canonical_user_id.current.id}"
   }
@@ -86,10 +79,8 @@ resource "aws_s3_bucket" "jazz_s3_api_doc" {
     allowed_origins = ["*"]
     max_age_seconds = 3000
   }
-  tags = "${merge(var.additional_tags, map(
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
   website {
     index_document = "index.html"
   }
@@ -136,10 +127,8 @@ resource "aws_s3_bucket" "jazz-web" {
     allowed_origins = ["*"]
     max_age_seconds = 3000
   }
-  tags = "${merge(var.additional_tags, map(
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
   website {
     index_document = "index.html"
 
@@ -310,10 +299,8 @@ resource "aws_s3_bucket" "dev-serverless-static" {
     allowed_origins = ["*"]
     max_age_seconds = 3000
   }
-  tags = "${merge(var.additional_tags, map(
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
   provisioner "local-exec" {
     when = "destroy"
     on_failure = "continue"
@@ -332,10 +319,8 @@ resource "aws_s3_bucket" "stg-serverless-static" {
     allowed_origins = ["*"]
     max_age_seconds = 3000
   }
-  tags = "${merge(var.additional_tags, map(
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
+
   provisioner "local-exec" {
     when = "destroy"
     on_failure = "continue"
@@ -354,10 +339,7 @@ resource "aws_s3_bucket" "prod-serverless-static" {
     allowed_origins = ["*"]
     max_age_seconds = 3000
   }
-  tags = "${merge(var.additional_tags, map(
-          "Application", "Jazz",
-          "JazzInstance", "${var.envPrefix}",
-          ))}"
+  tags = "${merge(var.additional_tags, local.common_tags)}"
 
   # TODO do we need this, or does `force_destroy` suffice?
   provisioner "local-exec" {

--- a/installscripts/jazz-terraform-unix-noinstances/scripts/modifyPropertyFile.sh
+++ b/installscripts/jazz-terraform-unix-noinstances/scripts/modifyPropertyFile.sh
@@ -5,5 +5,9 @@ property_value=$2
 property_file_json=$3
 
 property_value=$(sed 's/[]\/$*.^|[]/\\&/g' <<< $property_value)
-
-sed -i "s/\"$property_key\".*\"\"/\"$property_key\" : \"$property_value\"/g" $property_file_json
+if [ "$4" == "nostring" ]; then
+  property_value=$(sed "s/'/\"/g" <<< "$property_value")
+  sed -i "s/$property_key\".*.$/$property_key\" : $property_value/g" $property_file_json
+else
+  sed -i "s/\"$property_key\".*\"\"/\"$property_key\" : \"$property_value\"/g" $property_file_json
+fi

--- a/installscripts/jazz-terraform-unix-noinstances/tags.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/tags.tf
@@ -1,0 +1,10 @@
+locals {
+  common_tags = "${map(
+  "Name", "${var.envPrefix}",
+  "Application", "Jazz",
+  "JazzInstance", "${var.envPrefix}",
+  "Environment", "${var.tagsEnvironment}",
+  "Exempt", "${var.tagsExempt}",
+  "Owner", "${var.tagsOwner}"
+  )}"
+}

--- a/installscripts/jazz-terraform-unix-noinstances/terraform.tfvars
+++ b/installscripts/jazz-terraform-unix-noinstances/terraform.tfvars
@@ -51,3 +51,4 @@ codeq = false
 atlassian_jar_path = "~/jazz_tmp/atlassian-cli-6.7.1/lib/bitbucket-cli-6.7.0.jar"
 dockerizedJenkins = true
 additional_tags = {}
+aws_tags = ''

--- a/installscripts/jazz-terraform-unix-noinstances/terraform.tfvars
+++ b/installscripts/jazz-terraform-unix-noinstances/terraform.tfvars
@@ -50,3 +50,4 @@ scmgitlab = false
 codeq = false
 atlassian_jar_path = "~/jazz_tmp/atlassian-cli-6.7.1/lib/bitbucket-cli-6.7.0.jar"
 dockerizedJenkins = true
+additional_tags = {}

--- a/installscripts/jazz-terraform-unix-noinstances/variables.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/variables.tf
@@ -112,3 +112,4 @@ variable "additional_tags" {
   type = "map"
   default = {}
 }
+variable "aws_tags" { type = "string" }

--- a/installscripts/jazz-terraform-unix-noinstances/variables.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/variables.tf
@@ -108,3 +108,7 @@ variable "scmgitlab" { default = false }
 variable "codeq" { default = false }
 variable "atlassian_jar_path" { type = "string" }
 variable "dockerizedJenkins" {default = true}
+variable "additional_tags" {
+  type = "map"
+  default = {}
+}

--- a/installscripts/wizard/run.py
+++ b/installscripts/wizard/run.py
@@ -2,6 +2,7 @@
 import sys
 import os
 import jazz_scenarios as scenarios
+import validate_tags
 
 
 def main():
@@ -15,6 +16,14 @@ def main():
         os.environ['CODE_QUALITY'] = 'false'
         if len(sys.argv) > 3:
             os.environ['CODE_QUALITY'] = sys.argv[3]
+
+        if len(sys.argv) > 4:
+            input_tags = validate_tags.prepare_tags(sys.argv[4])
+            try:
+                os.environ['TF_VAR_AWS_TAGS'] = str(validate_tags.validate_replication_tags(input_tags))
+            except ValueError as err:
+                print("Invalid Tag!" + str(err))
+                sys.exit()
 
         os.environ['JAZZ_INSTALLER_ROOT'] = sys.argv[2]
         key = 0

--- a/installscripts/wizard/scenarios/support/jazz_common.py
+++ b/installscripts/wizard/scenarios/support/jazz_common.py
@@ -97,6 +97,12 @@ def replace_tfvars(key, value, fileName):
         r's|\(%s = \)\(.*\)|\1\"%s\"|g' % (key, value), fileName
     ])
 
+#replace it without double quotes
+def replace_tfvars_map(key, value, fileName):
+    subprocess.call([
+        'sed', "-i\'.bak\'",
+        r's|\(%s = \)\(.*\)|\1%s|g' % (key, value), fileName
+    ])
 
 def validate_email_id(email_id):
     """

--- a/installscripts/wizard/validate_tag_test.py
+++ b/installscripts/wizard/validate_tag_test.py
@@ -1,0 +1,52 @@
+import unittest
+import validate_tags
+
+class TestTags(unittest.TestCase):
+
+    def test_special_characters(self):
+        try:
+            replication_tags = [{'Value': 'testtag', 'Key': 'stackname'}]
+            result, formatted = validate_tags.validate_replication_tags(replication_tags)
+        except :
+            pass
+
+    def test_empty(self):
+        try:
+            replication_tags = [{'Value': '', 'Key': 'stackname#'}]
+            result, formatted = validate_tags.validate_replication_tags(replication_tags)
+            return True
+        except :
+            pass
+
+    def test_unique(self):
+        try:
+            replication_tags = [{'Value': 'testtag1', 'Key': 'stackname'}, {'Value': 'testtag2', 'Key': 'stackname'}]
+            result, formatted = validate_tags.validate_replication_tags(replication_tags)
+            self.assertEqual(type(result), list)
+        except :
+            pass
+
+    def test_key_length(self):
+        try:
+            lengthy_key = ''
+            for item in range(128):
+                lengthy_key += "a"
+            replication_tags = [{'Value': 'testtag1', 'Key': lengthy_key}]
+            result, formatted = validate_tags.validate_replication_tags(replication_tags)
+            self.assertEqual(type(result), list)
+        except :
+            pass
+
+    def test_value_length(self):
+        try:
+            lengthy_val = ''
+            for item in range(256):
+                lengthy_val += "a"
+            replication_tags = [{'Value': lengthy_val, 'Key': 'testkey'}]
+            result, formatted = validate_tags.validate_replication_tags(replication_tags)
+            self.assertEqual(type(result), list)
+        except :
+            pass
+
+if __name__ == '__main__':
+    unittest.main()

--- a/installscripts/wizard/validate_tags.py
+++ b/installscripts/wizard/validate_tags.py
@@ -42,10 +42,10 @@ def validate_replication_tags(replication_tags):
     if type(replication_tags) != list:
         raise ValueError("replication_tags should be a list")
 
-    reserved_tags = ["C01_USAGE"]
+    reserved_tags = ["name", "application", "jazzinstance", "environment", "exempt", "owner"]
     unique_tags = []
     new_replication_tags = []
-
+    tag_for_resource = '{'
     for tag in replication_tags:
 
         if not (type(tag) == dict and len(tag) == 2 and
@@ -68,11 +68,11 @@ def validate_replication_tags(replication_tags):
 
         unique_tags.append(Key)
         new_replication_tags.append({"Key": Key, "Value": Value})
-
+        tag_for_resource += Key+'="'+Value + '", '
         if len(new_replication_tags) > 49:
             raise ValueError("More than 50 tags in replication settings.")
 
-    return new_replication_tags
+    return new_replication_tags, tag_for_resource
 
 
 def prepare_tags(input_tags_param):

--- a/installscripts/wizard/validate_tags.py
+++ b/installscripts/wizard/validate_tags.py
@@ -71,7 +71,7 @@ def validate_replication_tags(replication_tags):
         tag_for_resource += Key+'="'+Value + '", '
         if len(new_replication_tags) > 49:
             raise ValueError("More than 50 tags in replication settings.")
-
+    tag_for_resource += '}'
     return new_replication_tags, tag_for_resource
 
 

--- a/installscripts/wizard/validate_tags.py
+++ b/installscripts/wizard/validate_tags.py
@@ -1,0 +1,83 @@
+import re
+def validate_replication_tags(replication_tags):
+    """
+    Returns validated replication tags or raises an error.
+    - 'replication_tags' should be a list of 'tag's.
+    - a 'tag' should be dictionary with Keys 'Key' and 'Value'
+    - the 'Key' Values should be a string with length between 0 and 127
+    - the 'Value' Values should be a string with length between 0 and 255
+    - the 'Key' Values should be unique
+    - the 'Key' and 'Value' Values must not start with 'aws'
+    - the 'Key' and 'Value' should be case sensitive
+    - the 'Key' and 'Value' should be alphanumeric plus the \
+      following special characters: + - = . _ : / @. with spaces
+    """
+
+    # helper method to validate Keys and Values
+    def validate_string(val, s_type, s_max_length):
+        if type(val) != str:
+            raise ValueError("Non string " + s_type + " found:" + str(val))
+        str_val = val.strip()
+        if not len(str_val):
+            raise ValueError("Empty " + s_type + " found.")
+        if len(str_val) >= s_max_length:
+            raise ValueError("Too long " + s_type + " found: " + str_val)
+        if str_val.lower().startswith("aws"):
+            raise ValueError(s_type + " starting with aws found: " + str_val)
+        return str_val
+
+    # helper method to validate spedical characters in Keys or Values
+    def validate_special_characters(item):
+        if not re.match("^[a-zA-Z0-9\s\+\-\=\.\_\:\/\@\.]*$", item):
+            raise ValueError("tag encountered with special character: " + item)
+
+    # helper method to validate case sensitive
+    def validate_case_sensitive(item):
+        to_check_str = item
+        for character in ["+", "-", "=", ".", "_", ":", "/", "@", ".", " "]:
+            to_check_str = to_check_str.replace(character, "")
+        if not to_check_str.islower() and not to_check_str.isupper() and to_check_str.isalnum():
+            raise ValueError("Tag Keys and Values are case sensitive: " + item)
+
+    if type(replication_tags) != list:
+        raise ValueError("replication_tags should be a list")
+
+    reserved_tags = ["C01_USAGE"]
+    unique_tags = []
+    new_replication_tags = []
+
+    for tag in replication_tags:
+
+        if not (type(tag) == dict and len(tag) == 2 and
+                'Key' in tag and 'Value' in tag):
+            raise ValueError("tags should be dicts with Keys 'Key' and 'Value'")
+
+        Key = validate_string(tag['Key'], 'Key', 127)
+        Value = validate_string(tag['Value'], 'Value', 255)
+
+        validate_special_characters(Key)
+        validate_special_characters(Value)
+        validate_case_sensitive(Key)
+        validate_case_sensitive(Value)
+
+        if Key in reserved_tags:
+            raise ValueError("tag encountered with reserved Key: " + Key)
+
+        if Key in unique_tags:
+            raise ValueError("tag encountered with duplicate Key: " + Key)
+
+        unique_tags.append(Key)
+        new_replication_tags.append({"Key": Key, "Value": Value})
+
+        if len(new_replication_tags) > 49:
+            raise ValueError("More than 50 tags in replication settings.")
+
+    return new_replication_tags
+
+
+def prepare_tags(input_tags_param):
+    input_tags = []
+    input_tags_rel = input_tags_param.split()
+    for item in input_tags_rel:
+      input_tags.append(dict(item2.split("=") for item2 in item.split(",")))
+    return input_tags

--- a/installscripts/wizard/validate_tags.py
+++ b/installscripts/wizard/validate_tags.py
@@ -20,7 +20,7 @@ def validate_replication_tags(replication_tags):
         str_val = val.strip()
         if not len(str_val):
             raise ValueError("Empty " + s_type + " found.")
-        if len(str_val) >= s_max_length:
+        if len(str_val) > s_max_length:
             raise ValueError("Too long " + s_type + " found: " + str_val)
         if str_val.lower().startswith("aws"):
             raise ValueError(s_type + " starting with aws found: " + str_val)
@@ -52,8 +52,8 @@ def validate_replication_tags(replication_tags):
                 'Key' in tag and 'Value' in tag):
             raise ValueError("tags should be dicts with Keys 'Key' and 'Value'")
 
-        Key = validate_string(tag['Key'], 'Key', 127)
-        Value = validate_string(tag['Value'], 'Value', 255)
+        Key = validate_string(tag['Key'], 'Key', 128)
+        Value = validate_string(tag['Value'], 'Value', 256)
 
         validate_special_characters(Key)
         validate_special_characters(Value)


### PR DESCRIPTION
**Applied validation for Tag Restrictions**

The following basic restrictions apply to tags:

- Maximum number of tags per resource – 50
- For each resource, each tag key must be unique, and each tag key can have only one value.
- Maximum key length – 128 Unicode characters in UTF-8
- Maximum value length – 256 Unicode characters in UTF-8
- If your tagging schema is used across multiple services and resources, remember that other services may have restrictions on allowed characters. Generally allowed characters are: letters, numbers, and spaces representable in UTF-8, and the following characters: + - = . _ : / @.
- Tag keys and values are case-sensitive.
- Don't use the aws: prefix for either keys or values; it's reserved for AWS use. You can't edit or delete tag keys or values with this prefix. Tags with this prefix do not count against your tags per resource limit.

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions

**Moved Additional tags to Installer vars json and terraform variables**
**Updated terraform resource to merge the additional tags along with General tags (Application, Exempt etc)**