### PR TITLE
Update UI config for apigee

### DIFF
--- a/installscripts/cookbooks/jenkins/files/default/jazz-installer-vars.json
+++ b/installscripts/cookbooks/jenkins/files/default/jazz-installer-vars.json
@@ -76,6 +76,11 @@
         "CAS_NAMESPACE_ID": ""
     },
     "UI_CONFIG": {
+        "CREATE_SERVICE": {
+          "API_DEPLOYMENT_TARGETS": true,
+          "FUNCTION_DEPLOYMENT_TARGETS": false,
+          "WEBSITE_DEPLOYMENT_TARGETS": false
+        },
         "feature": {
             "multi_env": true
         },


### PR DESCRIPTION
Update the missing UI config for deployment targets from UI.
These fields are used on UI to display the deployment targets that will be used by build packs to deploy to the correct platform
1) API : AWS API gateway, GCP Apigee
2) Function: AWS Lambda
3) Website: AWS S3, AWS Cloudfront

These were already added for development but were missed while adding them to this new branch