### PR TITLE
Add `shellcheck` to catch shell script syntax errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,4 @@ install:
 script:
   - test/check-tf.sh
   - test/check-py.sh
+  - test/check-bash.sh

--- a/test/check-bash.sh
+++ b/test/check-bash.sh
@@ -3,10 +3,12 @@
 # https://github.com/mozilla-platform-ops/devservices-aws/blob/master/runtests.sh
 set -euo pipefail
 main() {
-  echo -e '\n-----> Running terraform validate'
-  cd $TRAVIS_BUILD_DIR/installscripts/jazz-terraform-unix-noinstances
-  terraform init
-  terraform validate
+  echo -e '\n-----> Running shellcheck'
+  for d in $(git ls-files '*.sh' | xargs -n1 dirname | LC_ALL=C sort | uniq); do
+    echo -en "${d} "
+    shellcheck "${d}"
+    echo "✓"
+  done
   echo -e '\n-----> Success!'
 }
 main "$@"

--- a/test/check-bash.sh
+++ b/test/check-bash.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
-# This is inspired by:
-# https://github.com/mozilla-platform-ops/devservices-aws/blob/master/runtests.sh
-set -euo pipefail
-main() {
-  echo -e '\n-----> Running shellcheck'
-  for d in $(git ls-files '*.sh' | xargs -n1 dirname | LC_ALL=C sort | uniq); do
-    echo -en "${d} "
-    shellcheck "${d}"
-    echo "✓"
-  done
-  echo -e '\n-----> Success!'
-}
-main "$@"
+
+if [[ -z "$TRAVIS_PULL_REQUEST_BRANCH" ]]; then
+  BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
+else
+  BRANCH="master"
+fi
+
+exitcode=0
+for file in $(git diff --name-only $BRANCH | grep .sh\$); do
+  if [[ "$(shellcheck "$file")" -gt 0 ]]; then
+    echo "ERROR: $file failed to pass shellcheck lint step"
+    exitcode=1
+  fi
+done
+exit $exitcode

--- a/test/check-bash.sh
+++ b/test/check-bash.sh
@@ -6,11 +6,6 @@ else
   BRANCH="master"
 fi
 
-exitcode=0
 for file in $(git diff --name-only $BRANCH | grep .sh\$); do
-  if [[ "$(shellcheck "$file")" -gt 0 ]]; then
-    echo "ERROR: $file failed to pass shellcheck lint step"
-    exitcode=1
-  fi
+  shellcheck "$file"
 done
-exit $exitcode

--- a/test/check-py.sh
+++ b/test/check-py.sh
@@ -6,11 +6,6 @@ else
   BRANCH="master"
 fi
 
-exitcode=0
 for file in $(git diff --name-only $BRANCH | grep .py\$); do
-  if [[ "$(flake8 "$file")" -gt 0 ]]; then
-    echo "ERROR: $file failed to pass Python lint step"
-    exitcode=1
-  fi
+  flake8 "$file"
 done
-exit $exitcode

--- a/test/check-tf.sh
+++ b/test/check-tf.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 main() {
   echo -e '\n-----> Running terraform validate'
-  cd $TRAVIS_BUILD_DIR/installscripts/jazz-terraform-unix-noinstances
+  cd "$TRAVIS_BUILD_DIR/installscripts/jazz-terraform-unix-noinstances"
   terraform init
   terraform validate
   echo -e '\n-----> Success!'


### PR DESCRIPTION
Simplify TF and Python check and add `shellcheck` shell script linter/syntax error checker.

Like the `python` check, the shellscript checker will only analyze files that were touched as part of the PR, so we can incrementally improve.