### PR TITLE
Use correct target branch for Travis checks

### DIFF
--- a/test/check-bash.sh
+++ b/test/check-bash.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-if [[ -z "$TRAVIS_PULL_REQUEST_BRANCH" ]]; then
-  BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
+if [[ -z "$TRAVIS_BRANCH" ]]; then
+  BRANCH="$TRAVIS_BRANCH"
 else
   BRANCH="master"
 fi

--- a/test/check-py.sh
+++ b/test/check-py.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-if [[ -z "$TRAVIS_PULL_REQUEST_BRANCH" ]]; then
-  BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
+if [[ -z "$TRAVIS_BRANCH" ]]; then
+  BRANCH="$TRAVIS_BRANCH"
 else
   BRANCH="master"
 fi


### PR DESCRIPTION
Seems like the wrong branch variable was being used, so the checks were considering more files than they needed to.