### PR TITLE
Jenkins version set to 2.121.3, since latest version is not compatible

### DIFF
--- a/installscripts/dockerfiles/jenkins-ce/Dockerfile
+++ b/installscripts/dockerfiles/jenkins-ce/Dockerfile
@@ -1,5 +1,5 @@
 # Base Image and maintainer info
-FROM jenkins/jenkins:lts
+FROM jenkins/jenkins:2.121.3
 MAINTAINER JazzOSS Team
 
 # Switching to root to configure the image with system packages


### PR DESCRIPTION
The current jenkins after spin up is not compatible with the current jazz-core. This will be a blocker for the jazz setup. Hence raising this PR against master.

https://jenkins.io/changelog-stable/
Replace single per-user API token with new system of multiple, revocable, unrecoverable API tokens with usage tracking. (issue 32442, issue 32776, blog post)