### PR TITLE
Drop hardcoded date before our installer stops working

### DIFF
--- a/installscripts/dockerfiles/gitlab/launch_gitlab_docker.sh
+++ b/installscripts/dockerfiles/gitlab/launch_gitlab_docker.sh
@@ -87,7 +87,7 @@ spin_wheel $! "Installing lxml"
 
 # Generating private tokens
 echo "Generating private tokens:"
-python privatetoken.py mytoken 2018-12-31 $passwd
+python privatetoken.py mytoken $passwd
 echo "Private tokens generated"
 
 # Grabbing the admin credentials

--- a/installscripts/dockerfiles/gitlab/privatetoken.py
+++ b/installscripts/dockerfiles/gitlab/privatetoken.py
@@ -1,4 +1,4 @@
-#coding: utf-8
+# coding: utf-8
 import sys
 import requests
 from datetime import date

--- a/installscripts/dockerfiles/gitlab/privatetoken.py
+++ b/installscripts/dockerfiles/gitlab/privatetoken.py
@@ -1,6 +1,7 @@
 #coding: utf-8
 import sys
 import requests
+from datetime import date
 from urlparse import urljoin
 from bs4 import BeautifulSoup
 
@@ -37,9 +38,10 @@ def sign_in(login, password, csrf, cookies):
     return token, r.history[0].cookies
 
 
-def obtain_personal_access_token(name, expires_at, csrf, cookies):
+def obtain_personal_access_token(name, csrf, cookies):
+    today = date.today()
     data = {
-        u"personal_access_token[expires_at]": expires_at,
+        u"personal_access_token[expires_at]": today.replace(year=today.year + 1),
         u"personal_access_token[name]": name,
         u"personal_access_token[scopes][]": u"api",
         u"utf8": u"✓"
@@ -54,14 +56,13 @@ def obtain_personal_access_token(name, expires_at, csrf, cookies):
 
 def main():
     login = u"root"
-    password = sys.argv[3]
+    password = sys.argv[2]
 
     csrf1, cookies1 = obtain_csrf_token()
     csrf2, cookies2 = sign_in(login, password, csrf1, cookies1)
 
     name = sys.argv[1]
-    expires_at = sys.argv[2]
-    token = obtain_personal_access_token(name, expires_at, csrf2, cookies2)
+    token = obtain_personal_access_token(name, csrf2, cookies2)
     f = open("credentials.txt", "a")
     f.write("Private Token: %s" % token)
     f.close()


### PR DESCRIPTION
Found this while refactoring the installer, and will redo this code significantly (avoiding all the dumping to files to pass data around between shell scripts and python), but split this out as an emergency fix so our installer doesn't stop working on Dec 31st of this year.

Travis will fail shellcheck on the `launch_gitlab.sh` script since it has a ton of issues, but since we're deleting that code soon I'm going to ask reviewers to ignore lint errors with that file specifically.