### PR TITLE
Remove hardcoded region

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
   - PATH="${HOME}/bin
   - TMPDIR="${TMPDIR:-/tmp}"
   - VERSION="0.11.7"
+  #this needs to be set for `terraform init` to work, and we need that to work for the Terraform CI checks
+  - AWS_DEFAULT_REGION="us-east-1"
 before_install:
   - if ! terraform version ; then
       mkdir -p "${HOME}/bin"

--- a/installscripts/jazz-terraform-unix-noinstances/providers.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/providers.tf
@@ -1,6 +1,5 @@
 provider "aws" {
   version = "~> 1.14"
-  region = "us-east-1"
 }
 
 provider "null" {


### PR DESCRIPTION
I originally added this because we have to run `terraform init` to install provider plugins as part of the Travis CI checks, and since that doesn't run the installer this value was not set.

I assumed the fixed value would be overridden by the installer but it was not, so fixed it properly by removing the static value and setting the appropriate env var for Travis runs, which Terraform should pick up on.