### PR TITLE
Fix deployment issue

### DIFF
--- a/installscripts/jazz-terraform-unix-noinstances/api-gateway.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/api-gateway.tf
@@ -11,12 +11,4 @@ resource "aws_api_gateway_rest_api" "jazz-stg" {
 resource "aws_api_gateway_rest_api" "jazz-prod" {
   name        = "${var.envPrefix}-prod"
   description = "PROD API Gateway"
-
-  provisioner "local-exec" {
-    command = "rm -rf jazz-core"
-  }
-  provisioner "local-exec" {
-    command = "git clone -b ${var.github_branch} ${var.github_repo} jazz-core --depth 1"
-
-  }
 }

--- a/installscripts/jazz-terraform-unix-noinstances/jenkins.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/jenkins.tf
@@ -36,7 +36,7 @@ resource "null_resource" "update_jenkins_configs" {
     command = "${var.modifyPropertyFile_cmd} API_DOC ${aws_s3_bucket.jazz_s3_api_doc.bucket} ${var.jenkinsjsonpropsfile}"
   }
   provisioner "local-exec" {
-    command = "${var.configureApikey_cmd} ${aws_api_gateway_rest_api.jazz-dev.id} ${aws_api_gateway_rest_api.jazz-stg.id} ${aws_api_gateway_rest_api.jazz-prod.id} ${var.jenkinsjsonpropsfile} ${var.jenkinsattribsfile} ${var.envPrefix}"
+    command = "${var.configureApikey_cmd} ${aws_api_gateway_rest_api.jazz-dev.id} ${aws_api_gateway_rest_api.jazz-stg.id} ${aws_api_gateway_rest_api.jazz-prod.id} ${var.jenkinsjsonpropsfile} ${var.envPrefix}"
   }
   provisioner "local-exec" {
     command = "${var.configureS3Names_cmd} ${aws_s3_bucket.oab-apis-deployment-dev.bucket} ${aws_s3_bucket.oab-apis-deployment-stg.bucket} ${aws_s3_bucket.oab-apis-deployment-prod.bucket} ${aws_s3_bucket.jazz-web.bucket} ${var.jenkinsjsonpropsfile}"

--- a/installscripts/jazz-terraform-unix-noinstances/s3bucket.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/s3bucket.tf
@@ -105,9 +105,6 @@ resource "aws_api_gateway_rest_api" "jazz-prod" {
     command = "git clone -b ${var.github_branch} ${var.github_repo} jazz-core --depth 1"
 
   }
-  provisioner "local-exec" {
-    command = "${var.configureApikey_cmd} ${aws_api_gateway_rest_api.jazz-dev.id} ${aws_api_gateway_rest_api.jazz-stg.id} ${aws_api_gateway_rest_api.jazz-prod.id} ${var.jenkinsjsonpropsfile} ${var.jenkinsattribsfile} ${var.envPrefix}"
-  }
 }
 
 resource "aws_s3_bucket" "jazz-web" {

--- a/installscripts/jazz-terraform-unix-noinstances/s3bucket.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/s3bucket.tf
@@ -97,6 +97,15 @@ EOF
   }
 
   provisioner "local-exec" {
+    command = "rm -rf jazz-core"
+  }
+
+  provisioner "local-exec" {
+    command = "git clone -b ${var.github_branch} ${var.github_repo} jazz-core --depth 1"
+
+  }
+
+  provisioner "local-exec" {
     command = "${var.deployS3Webapp_cmd} ${aws_s3_bucket.jazz-web.bucket} ${var.region} ${data.aws_canonical_user_id.current.id}"
   }
 }

--- a/installscripts/jazz-terraform-unix-noinstances/scripts/configureApikey.sh
+++ b/installscripts/jazz-terraform-unix-noinstances/scripts/configureApikey.sh
@@ -3,8 +3,7 @@ DEV_ID=$1
 STG_ID=$2
 PROD_ID=$3
 jenkinsjsonpropsfile=$4
-jenkinsattribsfile=$5
-env_name_prefix=$6
+env_name_prefix=$5
 
 sed -i "s/{AWS_DEV_API_ID_DEFAULT}/$DEV_ID/g" $jenkinsjsonpropsfile
 sed -i "s/{AWS_STG_API_ID_DEFAULT}/$STG_ID/g" $jenkinsjsonpropsfile

--- a/installscripts/jazz-terraform-unix-noinstances/scripts/configureApikey.sh
+++ b/installscripts/jazz-terraform-unix-noinstances/scripts/configureApikey.sh
@@ -5,9 +5,9 @@ PROD_ID=$3
 jenkinsjsonpropsfile=$4
 env_name_prefix=$5
 
-sed -i "s/{AWS_DEV_API_ID_DEFAULT}/$DEV_ID/g" $jenkinsjsonpropsfile
-sed -i "s/{AWS_STG_API_ID_DEFAULT}/$STG_ID/g" $jenkinsjsonpropsfile
-sed -i "s/{AWS_STG_API_ID_JAZZ}/$STG_ID/g" $jenkinsjsonpropsfile
-sed -i "s/{AWS_PROD_API_ID_JAZZ}/$PROD_ID/g" $jenkinsjsonpropsfile
-sed -i "s/{AWS_PROD_API_ID_DEFAULT}/$PROD_ID/g" $jenkinsjsonpropsfile
-sed -i "s/INSTANCE_PREFIX\".*.$/INSTANCE_PREFIX\": \"$env_name_prefix\",/g" $jenkinsjsonpropsfile
+sed -i "s/{AWS_DEV_API_ID_DEFAULT}/$DEV_ID/g" "$jenkinsjsonpropsfile"
+sed -i "s/{AWS_STG_API_ID_DEFAULT}/$STG_ID/g" "$jenkinsjsonpropsfile"
+sed -i "s/{AWS_STG_API_ID_JAZZ}/$STG_ID/g" "$jenkinsjsonpropsfile"
+sed -i "s/{AWS_PROD_API_ID_JAZZ}/$PROD_ID/g" "$jenkinsjsonpropsfile"
+sed -i "s/{AWS_PROD_API_ID_DEFAULT}/$PROD_ID/g" "$jenkinsjsonpropsfile"
+sed -i "s/INSTANCE_PREFIX\".*.$/INSTANCE_PREFIX\": \"$env_name_prefix\",/g" "$jenkinsjsonpropsfile"


### PR DESCRIPTION
In the existing code, the `git clone` of `jazz-core` was being done in an unrelated API gateway resource, and not within the s3 bucket resource that was actually running the shell script to upload it, which required it.

So it sort of worked accidentally all this time, and when I split stuff up it exposed the bug. This fixes that.

Kudos to @rajeevr2715 for finding and pointing it out to me.