### PR TITLE
Persist default values for provider/account/region values into installer-vars.json

### DIFF
--- a/installscripts/cookbooks/jenkins/files/default/jazz-installer-vars.json
+++ b/installscripts/cookbooks/jenkins/files/default/jazz-installer-vars.json
@@ -8,6 +8,10 @@
         "CLOUDFRONT_ORIGIN_ID": "",
         "ACCOUNTID": "",
         "REGION": "",
+        "DEFAULTS": {
+            "REGION": "",
+            "ACCOUNTID": ""
+        },
         "ROLEID": "",
         "ES_HOSTNAME": "",
         "COGNITO": {
@@ -55,6 +59,9 @@
         },
         "SWAGGER": {
             "EDITOR_URL": "http://editor.swagger.io/?url="
+        },
+        "DEFAULTS": {
+            "PROVIDER": "aws"
         }
     },
     "JENKINS": {


### PR DESCRIPTION
**Description of the Change**

Initialize values for keys below during jazz installation and add them to installer-vars.json - 
{
  "JAZZ": {
    "DEFAULTS": {
      "PROVIDER": "aws"
    }
  },
  "AWS": {
    "DEFAULTS": {
      "REGION": "$foo",
      "ACCOUNT_ID": "$bar"
    }
  }
}
**Possible Drawbacks**
N/A