### PR TITLE
To avoid provision script fail

### DIFF
--- a/centos7-provision.sh
+++ b/centos7-provision.sh
@@ -55,7 +55,9 @@ function spin_wheel () {
         sleep .05
     done
 
-    wait "$pid"
+    while s=$(ps -p "$pid" -o s=) && [[ "$s" && "$s" != 'Z' ]]; do
+        sleep 1
+    done
     exitcode=$?
     if [ $exitcode -gt 0 ]
     then


### PR DESCRIPTION
**Description**
To avoid error during provision


> fatal: index-pack failed
> error: waitpid for fetch-pack failed: No child processes