### PR TITLE
Fix npm install errors

### DIFF
--- a/centos7-provision.sh
+++ b/centos7-provision.sh
@@ -140,6 +140,10 @@ function install_packages () {
         spin_wheel $! "Installing unzip"
     fi
 
+    # Installing epel
+    sudo yum install epel-release -y &> /dev/null &
+    spin_wheel $! "Installing epel"
+
     # Create a temporary folder .
     # Here we will have all the temporary files needed and delete it at the end
     sudo rm -rf $INSTALL_DIR/jazz_tmp
@@ -169,20 +173,32 @@ function install_packages () {
 
     #Download and install pip
     if command -v pip > /dev/null; then
-        print_info "pip already installed, using it"
+      print_info "pip already installed, using it"
     else
-        curl -sL $PIP_URL -o get-pip.py
-        sudo python get-pip.py >>$LOG_FILE &
-        spin_wheel $! "Downloading and installing pip"
+      curl -sL "$PIP_URL" -o get-pip.py
+      sudo python get-pip.py >> "$LOG_FILE" &
+      spin_wheel $! "Downloading and installing pip"
     fi
 
     if command -v aws > /dev/null; then
-        print_info "awscli already installed, using it"
+      print_info "awscli already installed, using it"
     else
-        # Download and Install awscli
-        sudo pip install awscli >> $LOG_FILE &
-        spin_wheel $! "Downloading & installing awscli bundle"
+      # Download and Install awscli
+      sudo pip install awscli >> "$LOG_FILE" &
+      spin_wheel $! "Downloading & installing awscli bundle"
     fi
+
+    # Installing epel
+    sudo yum install epel-release -y &> /dev/null &
+    spin_wheel $! "Installing epel"
+
+    # Installing beautifulsoup4
+    sudo yum install python-beautifulsoup4 -y &> /dev/null &
+    spin_wheel $! "Installing beautifulsoup4"
+
+    # Installing lxml
+    sudo pip install lxml &> /dev/null &
+    spin_wheel $! "Installing lxml"
 
     #Undo output redirection and close unused file descriptors.
     exec 1>&3 3>&-

--- a/installscripts/dockerfiles/gitlab/launch_gitlab_docker.sh
+++ b/installscripts/dockerfiles/gitlab/launch_gitlab_docker.sh
@@ -73,18 +73,6 @@ docker cp gitlab.sh gitlab:/root/gitlab.sh
 docker exec gitlab /bin/bash /root/gitlab.sh $passwd $rootemail > credentials.txt 2>&1&
 spin_wheel $! "Setting up admin credentials"
 
-# Installing epel
-sudo yum install epel-release -y &> /dev/null &
-spin_wheel $! "Installing epel"
-
-# Installing beautifulsoup4
-sudo yum install python-beautifulsoup4 -y &> /dev/null &
-spin_wheel $! "Installing beautifulsoup4"
-
-# Installing lxml
-sudo pip install lxml &> /dev/null &
-spin_wheel $! "Installing lxml"
-
 # Generating private tokens
 echo "Generating private tokens:"
 python privatetoken.py mytoken $passwd

--- a/installscripts/dockerfiles/jenkins-ce/Dockerfile
+++ b/installscripts/dockerfiles/jenkins-ce/Dockerfile
@@ -7,7 +7,7 @@ USER root
 RUN apt-get update && apt-get install -y vim curl sudo libtool autoconf make unzip rsync gcc autogen shtool pkg-config lsb-release python python-dev python-pip python-setuptools groff less && \
 curl https://bootstrap.pypa.io/get-pip.py | python && pip install --upgrade awscli && apt-get clean && pip install virtualenv && /usr/bin/easy_install virtualenv
 RUN wget -O /opt/apache-maven-3.5.2-bin.tar.gz https://archive.apache.org/dist/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz && tar xzvf /opt/apache-maven-3.5.2-bin.tar.gz -C  /opt && export PATH=$PATH:/opt/apache-maven-3.5.2/bin >> /etc/profile.d/maven.sh && ln -sf /opt/apache-maven-3.5.2/bin/mvn /usr/bin/mvn
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash && apt-get install -y nodejs && npm install  -global serverless@1.30.0 @angular/cli@1.7.3 jshint
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash && apt-get install -y nodejs && npm install -global serverless@1.30.0 @angular/cli@1.7.3 jshint --unsafe
 # Copying plugins list. Downlading and installing plugins from Jenkins PluginsManager
 COPY dockerfiles/jenkins-ce/plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt


### PR DESCRIPTION
Stopgap fix for #396 

Current master is essentially broken, this is fixed in the `jenkins_docker` branch but because of how we favor long-running feature branches the fix never made its way back into `master` because that feature is not yet done (one could argue the current release should not have gone out as well, clearly it wasn't tested).

Issue: Normally, `npm` will purposefully fail if you run as a `root` user without `sudo`, which is good practice generally. However, when building a docker container, we are running as root by necessity, and do not care. The `--unsafe` param lets us bypass this check, and the install of `serverless` succeeds.

Also backported fixes around provisioning script bugs that have been fixed in `jenkins_docker`