### PR TITLE
Move permissions to push cloudwatch logs to platform role

### DIFF
--- a/installscripts/jazz-terraform-unix-noinstances/api-gateway.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/api-gateway.tf
@@ -54,3 +54,7 @@ resource "aws_cloudwatch_log_subscription_filter" "logfilter-prod" {
   destination_arn = "${aws_kinesis_stream.logs_stream_prod.arn}"
   distribution    = "Random"
 }
+
+resource "aws_api_gateway_account" "cloudwatchlogroleupdate" {
+  cloudwatch_role_arn = "${aws_iam_role.platform_role.arn}"
+}

--- a/installscripts/jazz-terraform-unix-noinstances/iam.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/iam.tf
@@ -39,7 +39,7 @@ resource "aws_iam_role_policy_attachment" "cognitopoweruser" {
 }
 
 resource "aws_iam_role_policy_attachment" "pushtocloudwatchlogs" {
-  role       = "${aws_iam_role.lambda_role.name}"
+  role       = "${aws_iam_role.platform_role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
 }
 
@@ -77,9 +77,9 @@ resource "aws_iam_role" "lambda_role" {
 EOF
 }
 
-resource "aws_iam_role_policy" "basic_execution_policy" {
-  name = "${var.envPrefix}_basic_execution_policy"
-  role = "${aws_iam_role.lambda_role.id}"
+resource "aws_iam_role_policy" "platform_service_policy" {
+  name = "${var.envPrefix}_platform_service_policy"
+  role = "${aws_iam_role.platform_role.id}"
 
   policy = <<EOF
 {


### PR DESCRIPTION
**Description**
In API Gateway, need an IAM role ARN that has write access to CloudWatch logs in your account. 
Lambda Execution role should have only one policy - AWSLambdaBasicExecutionRole
