### PR TITLE
Updated to stable version to fix the gitlab container issue

### DIFF
--- a/installscripts/dockerfiles/gitlab/launch_gitlab_docker.sh
+++ b/installscripts/dockerfiles/gitlab/launch_gitlab_docker.sh
@@ -60,7 +60,7 @@ docker run --detach \
     --volume /srv/gitlab/config:/etc/gitlab \
     --volume /srv/gitlab/logs:/var/log/gitlab \
     --volume /srv/gitlab/data:/var/opt/gitlab \
-    gitlab/gitlab-ce:latest &> /dev/null &
+    gitlab/gitlab-ce:11.3.0-ce.0 &> /dev/null &
 spin_wheel $! "Initializing the Gitlab Docker"
 
 sleep 180 &


### PR DESCRIPTION
**Requirement**
Fix the gitlab docker container issue with empty password

**Description**
gitlab cotainer with gitlab/gitlab-ce:latest version will fail on,

> yes yes| /opt/gitlab/bin/gitlab-rake gitlab:setup RAILS_ENV=production GITLAB_ROOT_EMAIL=$rootemail GITLAB_ROOT_PASSWORD=$passwd > ~/out.txt 2>&1
> grep -A4 Administrator ~/out.txt | tee -a ~/gitlab-creds.txt

Output this error, 

>  rake aborted!
> ActiveRecord::ProtectedEnvironmentError: You are attempting to run a destructive action against your 'production' database.

So, updating the docker to stable version  gitlab/gitlab-ce:11.3.0-ce.0 which was successfully tested in jenkins_docker branch