### PR TITLE
Updated security group destory dependency

### DIFF
--- a/installscripts/jazz-terraform-unix-noinstances/acl.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/acl.tf
@@ -29,8 +29,12 @@ resource "aws_rds_cluster_instance" "casbin-instance" {
 
 #TODO: CIDR block will be refined/more restricted in the next version
 resource "aws_security_group" "acl_sg" {
-    name = "acl_sg"
+    name_prefix = "${var.envPrefix}"
     description = "Aurora MySQL access"
+    revoke_rules_on_delete = true
+    lifecycle {
+     create_before_destroy = true
+    }
     ingress {
         from_port = "${var.acl_db_port}"
         to_port = "${var.acl_db_port}"


### PR DESCRIPTION
To avoid error when deleting security group, added unique name prefix and revoke_rules_on_delete

>  aws_security_group.acl_sg: DependencyViolation: resource sg-XXXX has a dependent object
> 	status code: 400, request id: XXXXX
