### PR TITLE
Core services for multiregion/account

### DIFF
--- a/centos7-provision.sh
+++ b/centos7-provision.sh
@@ -171,7 +171,7 @@ function install_packages () {
     # Installing jq
     sudo yum install jq -y &> /dev/null &
     spin_wheel $! "Installing jq"
-    
+
     # Installing beautifulsoup4
     sudo yum install python-beautifulsoup4 -y &> /dev/null &
     spin_wheel $! "Installing beautifulsoup4"
@@ -183,6 +183,10 @@ function install_packages () {
     # Installing boto3
     sudo pip install boto3 &> /dev/null &
     spin_wheel $! "Installing boto3"
+
+    # Installing retrying
+    sudo pip install retrying &> /dev/null &
+    spin_wheel $! "Installing retrying"
 
     #Undo output redirection and close unused file descriptors.
     exec 1>&3 3>&-

--- a/feature-extensions/multiaccount/account_cred.sh
+++ b/feature-extensions/multiaccount/account_cred.sh
@@ -4,12 +4,15 @@ CREDENTIAL_ID=$2
 ACCESSKEY=$3
 SECRETKEY=$4
 
+
 cat <<EOF | $JENKINS_CLI_CMD create-credentials-by-xml system::system::jenkins "(global)"
-<com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl>
+<com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsImpl plugin="aws-credentials@1.21">
   <scope>GLOBAL</scope>
   <id>$CREDENTIAL_ID</id>
-  <description>user created on bitbucket</description>
-  <username>$ACCESSKEY</username>
-  <password>$SECRETKEY</password>
-</com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl>
+  <description>AWS Credentials</description>
+  <accessKey>$ACCESSKEY</accessKey>
+  <secretKey>$SECRETKEY</secretKey>
+  <iamRoleArn></iamRoleArn>
+  <iamMfaSerialNumber></iamMfaSerialNumber>
+</com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsImpl>
 EOF

--- a/feature-extensions/multiaccount/api_config.py
+++ b/feature-extensions/multiaccount/api_config.py
@@ -10,6 +10,14 @@ def update_config(key, value, username, password, endpoint):
                   headers={"Content-Type": "application/json", "Authorization": "%s" % (token)})
 
 
+def get_config(username, password, endpoint):
+    token = obtain_token(username, password, endpoint)
+    response = requests.get(endpoint+'/jazz/admin/config',
+                            headers={"Content-Type": "application/json", "Authorization": "%s" % (token)})
+
+    return json.loads(response.content)
+
+
 def obtain_token(username, password, endpoint):
     data = '{"username":"%s","password":"%s"}' % (username, password)
     response = requests.post(endpoint+'/jazz/login', data=data, headers={"Content-Type": "application/json"})

--- a/feature-extensions/multiaccount/core.py
+++ b/feature-extensions/multiaccount/core.py
@@ -212,8 +212,8 @@ def createplatformrole(iamclient, name, role_document):
 def createoai(oai_client, name):
     response = oai_client.create_cloud_front_origin_access_identity(
                 CloudFrontOriginAccessIdentityConfig={
-                    'CallerReference': name,
-                    'Comment': name
+                    'CallerReference': "%s%s" % (name,  str(uuid.uuid4().hex)),
+                    'Comment': "%s%s" % (name,  str(uuid.uuid4().hex))
                 }
                 )
-    return "origin-access-identity/cloudfront/%" % (response['CloudFrontOriginAccessIdentity']['Id'])
+    return "origin-access-identity/cloudfront/%s" % (response['CloudFrontOriginAccessIdentity']['Id'])

--- a/feature-extensions/multiaccount/core.py
+++ b/feature-extensions/multiaccount/core.py
@@ -1,0 +1,219 @@
+import boto3
+import json
+import uuid
+import retrying
+
+
+role_document = {
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+        "Sid": "",
+        "Effect": "Allow",
+        "Principal": {
+            "Service": "apigateway.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole"
+    },
+    {
+        "Effect": "Allow",
+        "Principal": {
+            "Service": "lambda.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole"
+    }
+  ]
+}
+
+
+def deploy_core_service(args):
+    account_user = getAccountUser(args.aws_accesskey, args.aws_secretkey)
+    account_user_arn = getAccountUserArn(args.aws_accesskey, args.aws_secretkey)
+    account_id = getAccountId(args.aws_accesskey, args.aws_secretkey)
+    credential_id = "MultiAccount"+account_id
+    # prepare account json with account and regions
+    account_json = {"ACCOUNTID": account_id,
+                    "CREDENTIAL_ID": credential_id,
+                    "IAM": {},
+                    "REGIONS": []
+                    }
+    # loop multiple regions and each region-account, create
+    for item in args.aws_region:
+        api_client = boto3.client('apigateway',
+                                  aws_access_key_id=args.aws_accesskey,
+                                  aws_secret_access_key=args.aws_secretkey,
+                                  region_name=item)
+        # 3 API Gateway endpoints (DEV/STG/PROD) per account/region
+        api_prod = createapi('%s-prod' % (args.jazz_stackprefix), 'PROD', api_client)
+        api_stg = createapi('%s-stg' % (args.jazz_stackprefix), 'STG', api_client)
+        api_dev = createapi('%s-dev' % (args.jazz_stackprefix), 'DEV', api_client)
+        # 3 deployment-buckets (DEV/STG/PROD)  per account/region for sls to store deployment artifacts
+        bucket_client = boto3.client('s3',
+                                     aws_access_key_id=args.aws_accesskey,
+                                     aws_secret_access_key=args.aws_secretkey,
+                                     region_name=item)
+        bucket_prod = createbucket(args.jazz_stackprefix, 'prod', item, bucket_client)
+        bucket_stg = createbucket(args.jazz_stackprefix, 'stg', item, bucket_client)
+        bucket_dev = createbucket(args.jazz_stackprefix, 'dev', item, bucket_client)
+
+        # New OAI (origin access identity)
+        oai_client = boto3.client('cloudfront',
+                                  aws_access_key_id=args.aws_accesskey,
+                                  aws_secret_access_key=args.aws_secretkey,
+                                  region_name=item)
+        oai_id = createoai(oai_client, "%soai" % (args.jazz_stackprefix))
+        account_json["REGIONS"].append({"REGION": item,
+                                        "API_GATEWAY": {"PROD": api_prod, "STG": api_stg, "DEV": api_dev},
+                                        "S3": {"PROD": bucket_prod, "STG": bucket_stg, "DEV": bucket_dev},
+                                        "CLOUDFRONT": {"CLOUDFRONT_ORIGIN_ID": oai_id}})
+        # Prepare assume role for each regions
+        # Add a trust policy to the "logs destination"
+        role_document['Statement'].append({
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "logs.%s.amazonaws.com" % (item)
+            },
+            "Action": "sts:AssumeRole"
+        })
+    iam_client = boto3.client('iam',
+                              aws_access_key_id=args.aws_accesskey,
+                              aws_secret_access_key=args.aws_secretkey)
+    # Basic IAM role with minimum permissions (cloudwatch:*)
+    basic_role_arn = createbasicrole(iam_client, "%s_basic_execution" % (args.jazz_stackprefix), role_document)
+    # One platform IAM role for the new account to use for integrations within the new account
+    platform_role_arn = createplatformrole(iam_client, "%s_platform_services" % (args.jazz_stackprefix), role_document)
+    account_json['IAM'] = {"USER": account_user,
+                           "USER_ARN": account_user_arn,
+                           "PLATFORMSERVICES_ROLEID": platform_role_arn,
+                           "USERSERVICES_ROLEID": basic_role_arn,
+                           }
+
+    return account_json, credential_id
+
+
+def getAccountUser(accessKey, secretKey):
+    obj_iam = boto3.resource('iam', aws_access_key_id=accessKey, aws_secret_access_key=secretKey)
+    return obj_iam.CurrentUser().user_name
+
+
+def getAccountUserArn(accessKey, secretKey):
+    obj_iam = boto3.resource('iam', aws_access_key_id=accessKey, aws_secret_access_key=secretKey)
+    return obj_iam.CurrentUser().arn
+
+
+def getAccountId(accessKey, secretKey):
+    return boto3.client('sts',
+                        aws_access_key_id=accessKey,
+                        aws_secret_access_key=secretKey).get_caller_identity().get('Account')
+
+
+@retrying.retry(wait_exponential_multiplier=1000, wait_exponential_max=10000)
+def createapi(name, description, api_client):
+    api_response = api_client.create_rest_api(
+                        name=name,
+                        description=description,
+     )
+    return api_response['id']
+
+
+@retrying.retry(wait_exponential_multiplier=1000, wait_exponential_max=10000)
+def createbucket(prefix, stage, region, bucket_client):
+    bucket_name = prepare_bucket_name(prefix, stage)
+    canonical_id = bucket_client.list_buckets()['Owner']['ID']
+    if region != 'us-east-1':
+        bucket_client.create_bucket(
+                    Bucket=bucket_name,
+                    CreateBucketConfiguration={'LocationConstraint': region},
+                    GrantFullControl="id=%s,uri=http://acs.amazonaws.com/groups/s3/LogDelivery" % (canonical_id)
+        )
+    else:
+        bucket_client.create_bucket(
+                    Bucket=bucket_name,
+                    GrantFullControl="id=%s,uri=http://acs.amazonaws.com/groups/s3/LogDelivery" % (canonical_id)
+        )
+    bucket_client.put_bucket_cors(
+        Bucket=bucket_name,
+        CORSConfiguration={
+            'CORSRules': [
+                {
+                    'AllowedHeaders': [
+                        'Authorization',
+                    ],
+                    'AllowedMethods': [
+                        'GET',
+                    ],
+                    'AllowedOrigins': [
+                        '*',
+                    ],
+                    'MaxAgeSeconds': 3000
+                },
+            ]
+            })
+    return bucket_name
+
+
+def prepare_bucket_name(prefix, stage):
+    return ''.join(["%s-%s-" % (prefix, stage), str(uuid.uuid4().hex)])
+
+
+def createrole(iamclient, name, role_document):
+    response = iamclient.create_role(
+                RoleName=name,
+                AssumeRolePolicyDocument=json.dumps(role_document)
+    )
+    return response['Role']['Arn']
+
+
+def attach_role(iamclient, name, policyarn):
+    iamclient.attach_role_policy(
+            RoleName=name,
+            PolicyArn=policyarn
+            )
+
+
+def createbasicrole(iamclient, name, role_document):
+    role_arn = createrole(iamclient, name, role_document)
+    attach_role(iamclient, name, 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole')
+
+    return role_arn
+
+
+def createplatformrole(iamclient, name, role_document):
+    role_arn = createrole(iamclient, name, role_document)
+    role_inline = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": [
+                        "iam:PassRole"
+                        ],
+                    "Effect": "Allow",
+                    "Resource": "*"
+                }
+                ]
+                }
+    iamclient.put_role_policy(
+             RoleName=name,
+             PolicyName='%s_platform_service_policy' % (name),
+             PolicyDocument=json.dumps(role_inline)
+             )
+    attach_role(iamclient, name, 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole')
+    attach_role(iamclient, name, 'arn:aws:iam::aws:policy/AWSLambdaFullAccess')
+    attach_role(iamclient, name, 'arn:aws:iam::aws:policy/AmazonAPIGatewayInvokeFullAccess')
+    attach_role(iamclient, name, 'arn:aws:iam::aws:policy/AmazonKinesisFullAccess')
+    attach_role(iamclient, name, 'arn:aws:iam::aws:policy/AmazonS3FullAccess')
+    attach_role(iamclient, name, 'arn:aws:iam::aws:policy/AmazonSQSFullAccess')
+    attach_role(iamclient, name, 'arn:aws:iam::aws:policy/AmazonCognitoPowerUser')
+    attach_role(iamclient, name, 'arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs')
+
+    return role_arn
+
+
+def createoai(oai_client, name):
+    response = oai_client.create_cloud_front_origin_access_identity(
+                CloudFrontOriginAccessIdentityConfig={
+                    'CallerReference': name,
+                    'Comment': name
+                }
+                )
+    return "origin-access-identity/cloudfront/%" % (response['CloudFrontOriginAccessIdentity']['Id'])

--- a/feature-extensions/multiaccount/core.py
+++ b/feature-extensions/multiaccount/core.py
@@ -38,6 +38,7 @@ def deploy_core_service(args):
                     "IAM": {},
                     "REGIONS": []
                     }
+    get_configjson = get_config(args.jazz_username, args.jazz_password, args.jazz_apiendpoint)
     # loop multiple regions and each region-account, create
     for item in args.aws_region:
         api_client = boto3.client('apigateway',
@@ -65,7 +66,7 @@ def deploy_core_service(args):
         oai_id = createoai(oai_client, "%soai" % (args.jazz_stackprefix))
 
         #Prepare destination arn for regions
-        destarn_dict = preparelogdestion(item, args)
+        destarn_dict = preparelogdestion(item, args, get_configjson)
 
         account_json["REGIONS"].append({"REGION": item,
                                         "API_GATEWAY": {"PROD": api_prod, "STG": api_stg, "DEV": api_dev},
@@ -225,8 +226,7 @@ def createoai(oai_client, name):
     return "origin-access-identity/cloudfront/%s" % (response['CloudFrontOriginAccessIdentity']['Id'])
 
 
-def preparelogdestion(region, args):
-    get_configjson = get_config(args.jazz_username, args.jazz_password, args.jazz_apiendpoint)
+def preparelogdestion(region, args, get_configjson):
     primary_account = get_configjson['data']['config']['AWS']['ACCOUNTID']
     destarn_prod = preparedestarn(region, primary_account, args.jazz_stackprefix, "prod")
     destarn_dev = preparedestarn(region, primary_account, args.jazz_stackprefix, "dev")

--- a/installscripts/jazz-terraform-unix-noinstances/iam.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/iam.tf
@@ -68,7 +68,7 @@ resource "aws_iam_role" "lambda_role" {
     {
         "Effect": "Allow",
         "Principal": {
-            "Service": "logs.${var.region}.amazonaws.com"
+            "Service": "logs.amazonaws.com"
         },
         "Action": "sts:AssumeRole"
     }
@@ -122,7 +122,7 @@ resource "aws_iam_role" "platform_role" {
     {
         "Effect": "Allow",
         "Principal": {
-            "Service": "logs.${var.region}.amazonaws.com"
+            "Service": "logs.amazonaws.com"
         },
         "Action": "sts:AssumeRole"
     }

--- a/installscripts/jazz-terraform-unix-noinstances/kinesis.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/kinesis.tf
@@ -75,3 +75,50 @@ resource "aws_kinesis_stream" "logs_stream_prod" {
 
   tags = "${merge(var.additional_tags, local.common_tags)}"
 }
+
+#Tried dynamic list, but found issue - https://github.com/hashicorp/terraform/issues/18682
+
+# PROD
+resource "aws_cloudwatch_log_destination" "prod_east1_kinesis" {
+  provider = "aws.east1"
+  name       = "${var.envPrefix}-prod_east1_kinesis"
+  role_arn   = "${aws_iam_role.platform_role.arn}"
+  target_arn = "${aws_kinesis_stream.logs_stream_prod.arn}"
+}
+
+resource "aws_cloudwatch_log_destination" "prod_west2_kinesis" {
+  provider = "aws.west2"
+  name       = "${var.envPrefix}-prod_west2_kinesis"
+  role_arn   = "${aws_iam_role.platform_role.arn}"
+  target_arn = "${aws_kinesis_stream.logs_stream_prod.arn}"
+}
+
+#DEV
+resource "aws_cloudwatch_log_destination" "dev_east1_kinesis" {
+  provider = "aws.east1"
+  name       = "${var.envPrefix}-dev_east1_kinesis"
+  role_arn   = "${aws_iam_role.platform_role.arn}"
+  target_arn = "${aws_kinesis_stream.logs_stream_dev.arn}"
+}
+
+resource "aws_cloudwatch_log_destination" "dev_west2_kinesis" {
+  provider = "aws.west2"
+  name       = "${var.envPrefix}-dev_west2_kinesis"
+  role_arn   = "${aws_iam_role.platform_role.arn}"
+  target_arn = "${aws_kinesis_stream.logs_stream_dev.arn}"
+}
+
+#STG
+resource "aws_cloudwatch_log_destination" "stg_east1_kinesis" {
+  provider = "aws.east1"
+  name       = "${var.envPrefix}-stg_east1_kinesis"
+  role_arn   = "${aws_iam_role.platform_role.arn}"
+  target_arn = "${aws_kinesis_stream.logs_stream_stg.arn}"
+}
+
+resource "aws_cloudwatch_log_destination" "stg_west2_kinesis" {
+  provider = "aws.west2"
+  name       = "${var.envPrefix}-stg_west2_kinesis"
+  role_arn   = "${aws_iam_role.platform_role.arn}"
+  target_arn = "${aws_kinesis_stream.logs_stream_stg.arn}"
+}

--- a/installscripts/jazz-terraform-unix-noinstances/kinesis.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/kinesis.tf
@@ -81,14 +81,14 @@ resource "aws_kinesis_stream" "logs_stream_prod" {
 # PROD
 resource "aws_cloudwatch_log_destination" "prod_east1_kinesis" {
   provider = "aws.east1"
-  name       = "${var.envPrefix}-prod_east1_kinesis"
+  name       = "${var.envPrefix}-prod-us-east-1-kinesis"
   role_arn   = "${aws_iam_role.platform_role.arn}"
   target_arn = "${aws_kinesis_stream.logs_stream_prod.arn}"
 }
 
 resource "aws_cloudwatch_log_destination" "prod_west2_kinesis" {
   provider = "aws.west2"
-  name       = "${var.envPrefix}-prod_west2_kinesis"
+  name       = "${var.envPrefix}-prod-us-west-2-kinesis"
   role_arn   = "${aws_iam_role.platform_role.arn}"
   target_arn = "${aws_kinesis_stream.logs_stream_prod.arn}"
 }
@@ -96,14 +96,14 @@ resource "aws_cloudwatch_log_destination" "prod_west2_kinesis" {
 #DEV
 resource "aws_cloudwatch_log_destination" "dev_east1_kinesis" {
   provider = "aws.east1"
-  name       = "${var.envPrefix}-dev_east1_kinesis"
+  name       = "${var.envPrefix}-dev-us-east-1-kinesis"
   role_arn   = "${aws_iam_role.platform_role.arn}"
   target_arn = "${aws_kinesis_stream.logs_stream_dev.arn}"
 }
 
 resource "aws_cloudwatch_log_destination" "dev_west2_kinesis" {
   provider = "aws.west2"
-  name       = "${var.envPrefix}-dev_west2_kinesis"
+  name       = "${var.envPrefix}-dev-us-west-2-kinesis"
   role_arn   = "${aws_iam_role.platform_role.arn}"
   target_arn = "${aws_kinesis_stream.logs_stream_dev.arn}"
 }
@@ -111,14 +111,14 @@ resource "aws_cloudwatch_log_destination" "dev_west2_kinesis" {
 #STG
 resource "aws_cloudwatch_log_destination" "stg_east1_kinesis" {
   provider = "aws.east1"
-  name       = "${var.envPrefix}-stg_east1_kinesis"
+  name       = "${var.envPrefix}-stg-us-east-1-kinesis"
   role_arn   = "${aws_iam_role.platform_role.arn}"
   target_arn = "${aws_kinesis_stream.logs_stream_stg.arn}"
 }
 
 resource "aws_cloudwatch_log_destination" "stg_west2_kinesis" {
   provider = "aws.west2"
-  name       = "${var.envPrefix}-stg_west2_kinesis"
+  name       = "${var.envPrefix}-stg-us-west-2-kinesis"
   role_arn   = "${aws_iam_role.platform_role.arn}"
   target_arn = "${aws_kinesis_stream.logs_stream_stg.arn}"
 }

--- a/installscripts/jazz-terraform-unix-noinstances/providers.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/providers.tf
@@ -6,3 +6,13 @@ provider "aws" {
 provider "null" {
   version = "~> 1.0"
 }
+
+provider "aws" {
+  alias  = "east1"
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "west2"
+  region = "us-west-2"
+}

--- a/installscripts/jazz-terraform-unix-noinstances/scmProvisioner.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/scmProvisioner.tf
@@ -20,7 +20,7 @@ resource "null_resource" "copyJazzBuildModule" {
 resource "null_resource" "pushconfig" {
   depends_on = ["null_resource.postJenkinsConfiguration"]
   provisioner "local-exec" {
-    command = "python ${var.config_cmd} ${aws_dynamodb_table.installer_config_db.name} ${aws_dynamodb_table.installer_config_db.hash_key} ${var.envPrefix} ${var.jenkinsjsonpropsfile} ${var.region}"
+    command = "python ${var.config_cmd} ${aws_dynamodb_table.installer_config_db.name} ${aws_dynamodb_table.installer_config_db.hash_key} ${var.envPrefix} ${var.jenkinsjsonpropsfile} ${var.region} ${var.jazz_accountid} ${aws_iam_role.platform_role.arn} ${aws_iam_role.lambda_role.arn} ${aws_api_gateway_rest_api.jazz-dev.id} ${aws_api_gateway_rest_api.jazz-prod.id} ${aws_api_gateway_rest_api.jazz-stg.id} ${aws_s3_bucket.oab-apis-deployment-dev.arn} ${aws_s3_bucket.oab-apis-deployment-prod.arn} ${aws_s3_bucket.oab-apis-deployment-stg.arn} ${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   }
 }
 

--- a/installscripts/jazz-terraform-unix-noinstances/scripts/config.py
+++ b/installscripts/jazz-terraform-unix-noinstances/scripts/config.py
@@ -4,16 +4,65 @@ import sys
 import decimal
 import boto3
 
-dynamodb = boto3.resource('dynamodb', region_name=sys.argv[5])
 
-table = dynamodb.Table(sys.argv[1])
+tablename = sys.argv[1]
+confighashkey = sys.argv[2]
+envprefix = sys.argv[3]
+installervarsparth = sys.argv[4]
+region = sys.argv[5]
+account_id = sys.argv[6]
+platform_role = sys.argv[7]
+user_role = sys.argv[8]
+api_dev = sys.argv[9]
+api_prod = sys.argv[10]
+api_stg = sys.argv[11]
+bucket_dev = sys.argv[12]
+bucket_prod = sys.argv[13]
+bucket_stg = sys.argv[14]
+oai = sys.argv[15]
 
-with open(sys.argv[4]) as json_file:
+dynamodb = boto3.resource('dynamodb', region_name=region)
+table = dynamodb.Table(tablename)
+
+with open(installervarsparth) as json_file:
     config = json.load(json_file, parse_float=decimal.Decimal)
     config['SCM'] = {key: value for key, value in config['SCM'].items() if value}
+    # Store the primary account related information in AWS.ACCOUNTS list as primary
+    config['AWS']['ACCOUNTS'] = [{
+            "ACCOUNTID": account_id,
+            "PRIMARY": "true",
+            "CREDENTIAL_ID": "jazz_awscreds",
+            "IAM": {
+              "PLATFORMSERVICES_ROLEID": platform_role,
+              "USERSERVICES_ROLEID": user_role
+            },
+            "REGIONS": [
+              {
+                "API_GATEWAY": {
+                  "DEV": api_dev,
+                  "PROD": api_prod,
+                  "STG": api_stg
+                },
+                "CLOUDFRONT": {
+                  "CLOUDFRONT_ORIGIN_ID": "origin-access-identity/cloudfront/%s" % (oai)
+                },
+                "LOGS": {
+                  "DEV": "arn:aws:logs:%s:%s:destination:%s-dev-%s-kinesis" % (region, account_id, envprefix, region),
+                  "PROD": "arn:aws:logs:%s:%s:destination:%s-prod-%s-kinesis" % (region, account_id, envprefix, region),
+                  "STG": "arn:aws:logs:%s:%s:destination:%s-stg-%s-kinesis" % (region, account_id, envprefix, region)
+                },
+                "REGION": region,
+                "S3": {
+                  "DEV": bucket_dev,
+                  "PROD": bucket_prod,
+                  "STG": bucket_stg
+                }
+              }
+            ]
+    }]
     table.put_item(
         Item={
-            sys.argv[2]: sys.argv[3],
+            confighashkey: envprefix,
             'AWS_CREDENTIAL_ID': config['AWS_CREDENTIAL_ID'],
             'AWS': config['AWS'],
             'REPOSITORY': config['REPOSITORY'],


### PR DESCRIPTION
**Description**

Along with persisting credentials for supporting deployments to new region, installer should deploy following core components in the new account/region and update installer-vars.json with the information - 

3 deployment-buckets (DEV/STG/PROD)  per account/region for sls to store deployment artifacts

3 API Gateway endpoints (DEV/STG/PROD) per account/region

Basic IAM role (for user services) per account with minimum permissions (cloudwatch:*)

One IAM role for platform integrations (list of permissions - TBD) for the new account to use for integrations within the new account (for ex: API Gateway to talk to Lambda - lambda execution role)
One IAM role to read CW metrics so that Jazz can use assume this role to retrieve metrics from Jazz primary account. Also, allow Jazz primary account to perform assumeRole on this role.

For websites, create new OAI (origin access identity) to access content in S3 from Cloudfront

