### PR TITLE
Fixing name of the jenkins job that deletes resources

### DIFF
--- a/installscripts/jazz-terraform-unix-noinstances/scripts/triggerJenkinsDeleteResources.py
+++ b/installscripts/jazz-terraform-unix-noinstances/scripts/triggerJenkinsDeleteResources.py
@@ -30,7 +30,7 @@ def startJob(args):
             "jenkins-cli.jar"])
     jenkins_build_command = \
         ' java -jar jenkins-cli.jar -s http://%s '\
-        '-auth %s:%s build jenkins-delete-resources  -p input=%s' \
+        '-auth %s:%s build delete-resources  -p input=%s' \
         % (args.jenkins_url, args.jenkins_username,
             args.jenkins_password, args.account_details)
 


### PR DESCRIPTION
**Description of the Change**

- The job name on Jenkins was created as **delete-resources**, and while triggering from jenkins it uses **jenkins-delete-resources** as the job name. Fixing it by changing the job name to **delete-resources** 