### PR TITLE
Multi-Account-Installer side changes for Jazz Metrics API 

### DIFF
--- a/feature-extensions/multiaccount/core.py
+++ b/feature-extensions/multiaccount/core.py
@@ -86,10 +86,22 @@ def deploy_core_service(args, tags):
                               aws_access_key_id=args.aws_accesskey,
                               aws_secret_access_key=args.aws_secretkey)
     # Basic IAM role with minimum permissions (cloudwatch:*)
-    basic_role_arn = createbasicrole(iam_client, "%s_basic_execution" % (args.jazz_stackprefix), role_document, tags)
+    basic_role_arn = createbasicrole(iam_client, "%s_basic_execution" % (args.jazz_stackprefix), role_document)
+
+    role_document['Statement'].append({
+        "Effect": "Allow",
+        "Principal": {
+            "AWS": "arn:aws:iam::%s:role/%s_platform_services" % (get_configjson['data']['config']['AWS']['ACCOUNTID'],args.jazz_stackprefix)
+        },
+        "Action": "sts:AssumeRole"
+     })
+
     # One platform IAM role for the new account to use for integrations within the new account
-    platform_role_arn = createplatformrole(iam_client, "%s_platform_services" % (args.jazz_stackprefix),
-                                           role_document, tags)
+    platform_role_arn = createplatformrole(iam_client, "%s_platform_services" % (args.jazz_stackprefix), role_document)
+    # update permission policy on Primary Account
+    if(platform_role_arn):
+        updatePrimaryRole(platform_role_arn,args.jazz_stackprefix,get_configjson)
+
     account_json['IAM'] = {"USER": account_user,
                            "USER_ARN": account_user_arn,
                            "PLATFORMSERVICES_ROLEID": platform_role_arn,
@@ -259,3 +271,40 @@ def preparedestarn(region, account, stackprefix, stage):
                                                                 account,
                                                                 stackprefix,
                                                                 stage, region)
+
+
+def updatePrimaryRole(roleArn, stackprefix,get_configjson):
+    platformRolePrimary = get_configjson['data']['config']['AWS']['PLATFORMSERVICES_ROLEID']
+    permission_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "",
+                "Effect": "Allow",
+                "Action": "sts:AssumeRole",
+                "Resource": roleArn
+            }
+        ]
+    }
+    # Get the default profile
+    session = boto3.Session(profile_name='default')
+    # Create IAM client
+    iamClient = session.client('iam')
+    iam = iamClient.resource('iam')
+    policy = iam.Policy(platformRolePrimary)
+    version = policy.default_version
+    policyJson = version.document
+    # Check if Policy exists
+    if policyJson:
+        policyJson['Statement'].append(permission_policy)
+        iamClient.delete_policy(
+            PolicyArn='arn:aws:iam::%s:policy/%s_NonPrimaryAssumePolicy', %(primary_account,stackprefix)
+        ) 
+    else:
+        policyJson = permission_policy
+
+    iamclient.put_role_policy(
+        RoleName='%sjazz20190220_platform_services' %(stackprefix,
+        PolicyName='%s_NonPrimaryAssumePolicy' % (stackprefix),
+        PolicyDocument=json.dumps(policyJson)
+    )

--- a/feature-extensions/multiaccount/core.py
+++ b/feature-extensions/multiaccount/core.py
@@ -304,7 +304,7 @@ def updatePrimaryRole(roleArn, stackprefix,get_configjson):
         policyJson = permission_policy
 
     iamclient.put_role_policy(
-        RoleName='%sjazz20190220_platform_services' %(stackprefix,
+        RoleName='%s_platform_services' %(stackprefix,
         PolicyName='%s_NonPrimaryAssumePolicy' % (stackprefix),
         PolicyDocument=json.dumps(policyJson)
     )


### PR DESCRIPTION
**Requirement**
     While moving on to multi account feature, there is an need to get Metrics Data from non-primary Accounts. So we need to create Trust policy on non-primary Account and also primary account roles to be updated with the Assume role Policy

**Description of the change**

- Created Trust policies on platform service Roles for Non-primary Accounts 

- Updated Assume policy of Platform Service Roles of Primary Account
