### PR TITLE
Multi-Account add GetRolePolicy permission for Operational User

### DIFF
--- a/installscripts/jazz-terraform-unix-noinstances/operationalUser.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/operationalUser.tf
@@ -45,7 +45,8 @@ resource "aws_iam_user_policy" "operational_policy" {
         "iam:DeleteRole",
         "iam:AttachRolePolicy",
         "iam:UpdateRole",
-        "iam:PutRolePolicy"
+        "iam:PutRolePolicy",
+        "iam:GetRolePolicy"
       ],
       "Effect": "Allow",
       "Resource": [


### PR DESCRIPTION
**Description of the Change**

- GetRolePolicy is been used to check whether rolepolicy exists in tear down resources

- Updating GetRolePolicy for Operational User.