### PR TITLE
Subnets to be created under the availablity zone

### DIFF
--- a/installscripts/jazz-terraform-unix-noinstances/acl.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/acl.tf
@@ -2,7 +2,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_rds_cluster" "casbin" {
   cluster_identifier      = "${var.envPrefix}-${var.acl_db_name}-cluster"
-  availability_zones      = ["${slice(data.aws_availability_zones.available.names, 0, 3)}"]
+  availability_zones      = ["${slice(data.aws_availability_zones.available.names, 0, 2)}"]
   database_name           = "${var.acl_db_name}"
   master_username         = "${var.acl_db_username}"
   master_password         = "${var.acl_db_password}"

--- a/installscripts/jazz-terraform-unix-noinstances/vpc_subnet.tf
+++ b/installscripts/jazz-terraform-unix-noinstances/vpc_subnet.tf
@@ -74,9 +74,9 @@ resource "aws_internet_gateway" "igw_for_ecs" {
 # Dynamic Subnet creation
 
 resource "aws_subnet" "subnet_for_ecs" {
-  count             = "${var.dockerizedJenkins * length(list("${var.region}a","${var.region}b"))}"
+  count             = "${var.dockerizedJenkins * length(slice(data.aws_availability_zones.available.names, 0, 2))}"
   vpc_id            = "${data.aws_vpc.vpc_data.id}"
-  availability_zone = "${element(list("${var.region}a","${var.region}b"), count.index)}"
+  availability_zone = "${element(slice(data.aws_availability_zones.available.names, 0, 2), count.index)}"
   cidr_block        = "${cidrsubnet(data.aws_vpc.vpc_data.cidr_block, ceil(log(2 * 2, 2)), 2 + count.index)}"
   tags = "${merge(var.additional_tags, local.common_tags)}"
 }
@@ -136,9 +136,9 @@ resource "aws_nat_gateway" "natgtw" {
 }
 
 resource "aws_subnet" "subnet_for_ecs_private" {
-  count             = "${var.dockerizedJenkins * length(list("${var.region}a","${var.region}b"))}"
+  count             = "${var.dockerizedJenkins * length(slice(data.aws_availability_zones.available.names, 0, 2))}"
   vpc_id            = "${data.aws_vpc.vpc_data.id}"
-  availability_zone = "${element(list("${var.region}a","${var.region}b"), count.index)}"
+  availability_zone = "${element(slice(data.aws_availability_zones.available.names, 0, 2), count.index)}"
   cidr_block        = "${cidrsubnet(data.aws_vpc.vpc_data.cidr_block, ceil(log(4 * 2, 2)), 2 + count.index)}"
   tags = "${merge(var.additional_tags, local.common_tags)}"
 }


### PR DESCRIPTION
### Requirements

* To fix the issue the availability zones specified in RDS resources should be present in the subnets which are specified in subnet group in RDS.

> aws_rds_cluster.casbin: error creating RDS cluster: InvalidVPCNetworkStateFault: Availability zone '[us-east-1c]' is unavailable in this region, please choose another zone set.



### Description of the Change

limit the availability zone to 2

### Benefits

Fix the issue -  aws_rds_cluster.casbin: error creating RDS cluster: InvalidVPCNetworkStateFault: Availability zone '[us-east-1c]' is unavailable in this region, please choose another zone set.

### Possible Drawbacks

NA

### Applicable Issues

NA
