### PR TITLE
Elasticsearch (for Jazz logs) as container hosted in ECS (Fargate) instead of current managed ES

### DIFF
--- a/installer/terraform/ecs.tf
+++ b/installer/terraform/ecs.tf
@@ -589,3 +589,11 @@ resource "null_resource" "health_check_es" {
     command = "python ${var.healthCheck_cmd} ${aws_alb_target_group.alb_target_group_es.arn}"
   }
 }
+
+resource "null_resource" "health_check_kibana" {
+  count = "${var.dockerizedJenkins}"
+  depends_on = ["aws_ecs_service.ecs_service_kibana"]
+  provisioner "local-exec" {
+    command = "python ${var.healthCheck_cmd} ${aws_alb_target_group.alb_target_group_kibana.arn}"
+  }
+}

--- a/installer/terraform/ecs_es_task_definition.json
+++ b/installer/terraform/ecs_es_task_definition.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "${ecs_container_name}",
+    "image": "${image}",
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": ${port_def},
+        "hostPort": ${port_def}
+      },
+      {
+        "containerPort": ${port_tcp},
+        "hostPort": ${port_tcp}
+      }
+    ],
+    "environment": [
+        {
+          "name": "allow_mmapfs",
+          "value": "false"
+        },
+        {
+          "name": "bootstrap.memory_lock",
+          "value": "false"
+        },
+        {
+          "name": "ES_JAVA_OPTS",
+          "value": "-Xms4096m -Xmx4096m"
+        },
+        {
+          "name": "MAX_MAP_COUNT",
+          "value": "262144"
+        },
+        {
+          "name": "node.store.allow_mmapfs",
+          "value": "false"
+        }
+      ],
+    "memoryReservation": ${memory},
+    "networkMode": "awsvpc",
+    "cpu": ${cpu},
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${log_group}",
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "${prefix_name}"
+      }
+    },
+    "ulimits": [
+        {
+          "name": "memlock",
+          "softLimit": -1,
+          "hardLimit": -1
+        },
+        {
+          "name": "nofile",
+          "softLimit": 65536,
+          "hardLimit": 65536
+        }
+      ]
+  }
+]

--- a/installer/terraform/ecs_kibana_task_definition.json
+++ b/installer/terraform/ecs_kibana_task_definition.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "${ecs_container_name}",
+    "image": "${image}",
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": ${port_def},
+        "hostPort": ${port_def}
+      }
+    ],
+    "environment": [
+        {
+         "name": "ELASTICSEARCH_URL",
+         "value": "${esurl}"
+       }
+      ],
+    "memoryReservation": ${memory},
+    "networkMode": "awsvpc",
+    "cpu": ${cpu},
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${log_group}",
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "${prefix_name}"
+      }
+    }
+  }
+]

--- a/installer/terraform/elasticsearch.tf
+++ b/installer/terraform/elasticsearch.tf
@@ -1,4 +1,5 @@
 resource "aws_elasticsearch_domain" "elasticsearch_domain" {
+  count = "${1-var.dockerizedJenkins}"
   domain_name           = "${var.envPrefix}"
   elasticsearch_version = "5.1"
   cluster_config {
@@ -42,6 +43,7 @@ POLICIES
 #we will just create one.
 #TODO Not a huge fan of `on_failure continue`, we need a smarter way to decide if this needs to be run or not
 resource "null_resource" "updateSecurityGroup" {
+   count = "${1-var.dockerizedJenkins}"
    provisioner "local-exec" {
     command    = "aws ec2 authorize-security-group-ingress --group-id ${lookup(var.jenkinsservermap, "jenkins_security_group")} --protocol tcp --port 443 --source-group ${lookup(var.jenkinsservermap, "jenkins_security_group")} --region ${var.region}"
     on_failure = "continue"

--- a/installer/terraform/elasticsearch.tf
+++ b/installer/terraform/elasticsearch.tf
@@ -1,7 +1,7 @@
 resource "aws_elasticsearch_domain" "elasticsearch_domain" {
   count = "${1-var.dockerizedJenkins}"
   domain_name           = "${var.envPrefix}"
-  elasticsearch_version = "5.1"
+  elasticsearch_version = "6.5"
   cluster_config {
     instance_type = "m3.medium.elasticsearch"
     instance_count =2

--- a/installer/terraform/jenkins.tf
+++ b/installer/terraform/jenkins.tf
@@ -35,9 +35,11 @@ resource "null_resource" "update_jenkins_configs" {
     command = "${var.configureESEndpoint_cmd} ${var.dockerizedJenkins == 1 ? format("http://%s:%s", join(" ", aws_lb.alb_ecs_es_kibana.*.dns_name), var.es_port_def ) : format("http://%s", join(" ",aws_elasticsearch_domain.elasticsearch_domain.*.endpoint))} ${var.dockerizedJenkins == 1 ? format("http://%s:%s", join(" ", aws_lb.alb_ecs_es_kibana.*.dns_name), var.kibana_port_def) : format("https://%s%s", join(" ", aws_elasticsearch_domain.elasticsearch_domain.*.endpoint), "/_plugin/kibana")}"
   }
   provisioner "local-exec" {
-    command = "${var.modifyPropertyFile_cmd} ES_HOSTNAME ${var.dockerizedJenkins == 1 ? format("%s:%s", join(" ", aws_lb.alb_ecs_es_kibana.*.dns_name), var.es_port_def ) : join(" ",aws_elasticsearch_domain.elasticsearch_domain.*.endpoint)} ${var.jenkinsjsonpropsfile}"
+    command = "${var.modifyPropertyFile_cmd} ES_HOSTNAME ${var.dockerizedJenkins == 1 ? format("http://%s:%s", join(" ", aws_lb.alb_ecs_es_kibana.*.dns_name), var.es_port_def ) : format("http://%s", join(" ",aws_elasticsearch_domain.elasticsearch_domain.*.endpoint))} ${var.jenkinsjsonpropsfile}"
   }
-
+  provisioner "local-exec" {
+    command = "${var.modifyPropertyFile_cmd} KIBANA_HOSTNAME ${var.dockerizedJenkins == 1 ? format("http://%s:%s", join(" ", aws_lb.alb_ecs_es_kibana.*.dns_name), var.kibana_port_def) : format("https://%s%s", join(" ", aws_elasticsearch_domain.elasticsearch_domain.*.endpoint), "/_plugin/kibana")} ${var.jenkinsjsonpropsfile}"
+  }
   #TODO why do we need these following to values in addition to the previous ones?
   provisioner "local-exec" {
     command = "${var.modifyPropertyFile_cmd} {AWS_STG_API_ID_JAZZ} ${aws_api_gateway_rest_api.jazz-stg.id} ${var.jenkinsjsonpropsfile} BY_VALUE"

--- a/installer/terraform/jenkins.tf
+++ b/installer/terraform/jenkins.tf
@@ -32,7 +32,7 @@ resource "null_resource" "update_jenkins_configs" {
 
   #Elasticsearch
   provisioner "local-exec" {
-    command = "${var.configureESEndpoint_cmd} ${var.dockerizedJenkins == 1 ? format("http://%s:%s", join(" ", aws_lb.alb_ecs_es_kibana.*.dns_name), var.es_port_def ) : format("http://%s", join(" ",aws_elasticsearch_domain.elasticsearch_domain.*.endpoint))} ${var.dockerizedJenkins == 1 ? format("http://%s:%s", join(" ", aws_lb.alb_ecs_es_kibana.*.dns_name), var.kibana_port_def) : format("https://%s%s", join(" ", aws_elasticsearch_domain.elasticsearch_domain.*.endpoint), "/.kibana")}"
+    command = "${var.configureESEndpoint_cmd} ${var.dockerizedJenkins == 1 ? format("http://%s:%s", join(" ", aws_lb.alb_ecs_es_kibana.*.dns_name), var.es_port_def ) : format("http://%s", join(" ",aws_elasticsearch_domain.elasticsearch_domain.*.endpoint))} ${var.dockerizedJenkins == 1 ? format("http://%s:%s", join(" ", aws_lb.alb_ecs_es_kibana.*.dns_name), var.kibana_port_def) : format("https://%s%s", join(" ", aws_elasticsearch_domain.elasticsearch_domain.*.endpoint), "/_plugin/kibana")}"
   }
   provisioner "local-exec" {
     command = "${var.modifyPropertyFile_cmd} ES_HOSTNAME ${var.dockerizedJenkins == 1 ? format("%s:%s", join(" ", aws_lb.alb_ecs_es_kibana.*.dns_name), var.es_port_def ) : join(" ",aws_elasticsearch_domain.elasticsearch_domain.*.endpoint)} ${var.jenkinsjsonpropsfile}"

--- a/installer/terraform/jenkins.tf
+++ b/installer/terraform/jenkins.tf
@@ -1,5 +1,5 @@
 resource "null_resource" "update_jenkins_configs" {
-  depends_on = ["aws_cognito_user_pool_domain.domain"]
+  depends_on = ["aws_cognito_user_pool_domain.domain", "null_resource.health_check_kibana"]
 
   #Cloudfront
   provisioner "local-exec" {

--- a/installer/terraform/jenkins.tf
+++ b/installer/terraform/jenkins.tf
@@ -32,10 +32,10 @@ resource "null_resource" "update_jenkins_configs" {
 
   #Elasticsearch
   provisioner "local-exec" {
-    command = "${var.configureESEndpoint_cmd} ${aws_elasticsearch_domain.elasticsearch_domain.endpoint}"
+    command = "${var.configureESEndpoint_cmd} ${var.dockerizedJenkins == 1 ? format("http://%s:%s", join(" ", aws_lb.alb_ecs_es_kibana.*.dns_name), var.es_port_def ) : format("http://%s", join(" ",aws_elasticsearch_domain.elasticsearch_domain.*.endpoint))} ${var.dockerizedJenkins == 1 ? format("http://%s:%s", join(" ", aws_lb.alb_ecs_es_kibana.*.dns_name), var.kibana_port_def) : format("https://%s%s", join(" ", aws_elasticsearch_domain.elasticsearch_domain.*.endpoint), "/.kibana")}"
   }
   provisioner "local-exec" {
-    command = "${var.modifyPropertyFile_cmd} ES_HOSTNAME ${var.dockerizedJenkins == 1 ? format("%s/%s", join(" ", aws_lb.alb_ecs_es_kibana.*.dns_name), "var.es_port_def" ) : aws_elasticsearch_domain.elasticsearch_domain.endpoint} ${var.jenkinsjsonpropsfile}"
+    command = "${var.modifyPropertyFile_cmd} ES_HOSTNAME ${var.dockerizedJenkins == 1 ? format("%s:%s", join(" ", aws_lb.alb_ecs_es_kibana.*.dns_name), var.es_port_def ) : join(" ",aws_elasticsearch_domain.elasticsearch_domain.*.endpoint)} ${var.jenkinsjsonpropsfile}"
   }
 
   #TODO why do we need these following to values in addition to the previous ones?

--- a/installer/terraform/jenkins.tf
+++ b/installer/terraform/jenkins.tf
@@ -35,7 +35,7 @@ resource "null_resource" "update_jenkins_configs" {
     command = "${var.configureESEndpoint_cmd} ${aws_elasticsearch_domain.elasticsearch_domain.endpoint}"
   }
   provisioner "local-exec" {
-    command = "${var.modifyPropertyFile_cmd} ES_HOSTNAME ${aws_elasticsearch_domain.elasticsearch_domain.endpoint} ${var.jenkinsjsonpropsfile}"
+    command = "${var.modifyPropertyFile_cmd} ES_HOSTNAME ${var.dockerizedJenkins == 1 ? format("%s/%s", join(" ", aws_lb.alb_ecs_es_kibana.*.dns_name), "var.es_port_def" ) : aws_elasticsearch_domain.elasticsearch_domain.endpoint} ${var.jenkinsjsonpropsfile}"
   }
 
   #TODO why do we need these following to values in addition to the previous ones?

--- a/installer/terraform/provisioners/cookbooks/jenkins/files/default/jazz-installer-vars.json
+++ b/installer/terraform/provisioners/cookbooks/jenkins/files/default/jazz-installer-vars.json
@@ -34,6 +34,7 @@
           "FUNCTIONS": ["cloud-logs-streamer", "deployments-event-handler", "environment-event-handler", "es-kinesis-log-streamer"]
         },
         "ES_HOSTNAME": "",
+        "KIBANA_HOSTNAME": "",
         "PLATFORM": {
           "AWS": {
             "API_GATEWAY": {

--- a/installer/terraform/scripts/configureESEndpoint.sh
+++ b/installer/terraform/scripts/configureESEndpoint.sh
@@ -15,7 +15,7 @@ sed -i "s#{inst_elastic_search_hostname}#$ES_ENDPOINT#g " ./jazz-core/core/jazz_
 #--principal logs.$region.amazonaws.com
 
 #Sleeping for policies to be applied
-sleep 120
+#sleep 120
 # Configure ElasticSearch Template via json
 
 curl -X POST --url "$ES_ENDPOINT/_template/apilogs"  --data-binary @./jazz-core/core/jazz_cloud-logs-streamer/_ES/apilogs.json --header "Content-Type: application/json"
@@ -29,12 +29,12 @@ curl -XPUT "$ES_ENDPOINT/applicationlogs?pretty" --data-binary @./jazz-core/core
 echo "Creating index patterns..."
 index_pattern_applicationlogs="$KIBANA_ENDPOINT/api/saved_objects/index-pattern/applicationlogs"
 curl --include --silent --retry 5 --retry-delay 3 --output /dev/null -X POST "$index_pattern_applicationlogs" -H 'kbn-xsrf: true' -H 'Content-Type: application/json' -d '{
-  "attributes": {"title":"applicationlogs","timeFieldName":"@timestamp"}
+  "attributes": {"title":"applicationlogs","timeFieldName":"timestamp"}
 }'
 index_pattern_apilogs="$KIBANA_ENDPOINT/api/saved_objects/index-pattern/apilogs"
 curl --include --silent --retry 5 --retry-delay 3 --output /dev/null -X POST "$index_pattern_apilogs" -H 'kbn-xsrf: true' -H 'Content-Type: application/json' -d '
 {
-  "attributes": {"title":"apilogs","timeFieldName":"@timestamp"}
+  "attributes": {"title":"apilogs","timeFieldName":"timestamp"}
 }'
 
 echo "Default Index"

--- a/installer/terraform/variables.tf
+++ b/installer/terraform/variables.tf
@@ -150,3 +150,18 @@ variable "response_parameters_cors" {
      "gatewayresponse.header.Access-Control-Allow-Origin" = "'*'"
   }
  }
+variable "es_port_def" {type = "string" default = "9200"}
+variable "es_port_tcp" {type = "string" default = "9300"}
+variable "kibana_port_def" {type = "string" default = "5601"}
+variable "ecsEscpu" { type = "string" default = "2048" }
+variable "ecsEsmemory" { type = "string" default = "5120" }
+variable "ecsKibanacpu" { type = "string" default = "512" }
+variable "ecsKibanamemory" { type = "string" default = "2048" }
+variable "es_docker_image" {
+  type = "string"
+  default = "docker.elastic.co/elasticsearch/elasticsearch:6.5.0"
+}
+variable "kibana_docker_image" {
+  type = "string"
+  default = "docker.elastic.co/kibana/kibana:6.5.4"
+}

--- a/installer/terraform/vpc_subnet.tf
+++ b/installer/terraform/vpc_subnet.tf
@@ -45,6 +45,42 @@ resource "aws_security_group" "vpc_sg" {
         cidr_blocks = ["${concat(list("${aws_eip.elasticip.public_ip}/32"), list("${data.external.instance_ip.result.ip}/32"), split(",", var.network_range))}"]
     }
     ingress {
+        from_port = "${var.es_port_def}"
+        to_port = "${var.es_port_def}"
+        protocol = "tcp"
+        self = true
+    }
+    ingress {
+        from_port = "${var.es_port_def}"
+        to_port = "${var.es_port_def}"
+        protocol = "tcp"
+        cidr_blocks = ["${concat(list("${aws_eip.elasticip.public_ip}/32"), list("${data.external.instance_ip.result.ip}/32"), split(",", var.network_range))}"]
+    }
+    ingress {
+        from_port = "${var.es_port_tcp}"
+        to_port = "${var.es_port_tcp}"
+        protocol = "tcp"
+        self = true
+    }
+    ingress {
+        from_port = "${var.es_port_tcp}"
+        to_port = "${var.es_port_tcp}"
+        protocol = "tcp"
+        cidr_blocks = ["${concat(list("${aws_eip.elasticip.public_ip}/32"), list("${data.external.instance_ip.result.ip}/32"), split(",", var.network_range))}"]
+    }
+    ingress {
+        from_port = "${var.kibana_port_def}"
+        to_port = "${var.kibana_port_def}"
+        protocol = "tcp"
+        self = true
+    }
+    ingress {
+        from_port = "${var.kibana_port_def}"
+        to_port = "${var.kibana_port_def}"
+        protocol = "tcp"
+        cidr_blocks = ["${concat(list("${aws_eip.elasticip.public_ip}/32"), list("${data.external.instance_ip.result.ip}/32"), split(",", var.network_range))}"]
+    }
+    ingress {
         from_port = 9000
         to_port = 9000
         protocol = "tcp"


### PR DESCRIPTION
**Requirements**
Host Elasticsearch (for Jazz logs) as container a in ECS (Fargate) instead of current managed ES

**Description of the Change**
We currently provision AWS managed Elasticsearch service for log management. Similar to other jazz default components (gitlab, jenkins, sonarqube), we should be able to provision Elasticsearch as a container. 

https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html 

* Version upgraded to 6.5 in both AWS elastic search (scenario1) and Dockerized ES (scenario3)
* Updated the ES and Kibana endpoints in Config database.
