### PR TITLE
Request Apigee User Keys as part of using restrictive permissions

### DIFF
--- a/features/extensions/apigee/README.md
+++ b/features/extensions/apigee/README.md
@@ -43,6 +43,8 @@ Options:
   --apigee_userpass TEXT...       Provide the username and password     when
                                   accessing Apigee separated by a space
                                   [required]
+  --accesskey TEXT                AWS accesskey of the apigee user account
+  --secretkey TEXT                AWS secretkey of the apigee user account
   --help                          Show this message and exit.
 
 ```
@@ -73,6 +75,8 @@ python Apigee.py install --region REGION
                   --apigee_svc_prod_host APIGEE_PROD_SERVICEHOST
                   --apigee_svc_dev_host APIGEE_DEV_SERVICEHOST
                   --apigee_userpass APIGEEUSERNAME APIGEEPASSWORD
+                  --accesskey APIGEEAWSACCESSKEY
+                  --secretkey APIGEEAWSSECRETKEY
 
 ```
 
@@ -95,6 +99,8 @@ Apigee dev env:
 Apigee svc prod host:
 Apigee svc dev host:
 Apigee userpass [()]:
+AWS accesskey:
+Aws secretkey:
 ```
 
 

--- a/features/extensions/apigee/install.py
+++ b/features/extensions/apigee/install.py
@@ -85,9 +85,19 @@ from utils.jenkins import setCredential, startJob
     required=True,
     help='Provide the username and password when accessing Apigee separated by a space',
     prompt=True)
+@click.option(
+    "--accesskey",
+    help='AWS accesskey of the apigee user account',
+    prompt=True
+)
+@click.option(
+    "--secretkey",
+    help='AWS secretkey of the apigee user account',
+    prompt=True
+)
 def install(region, stackprefix, jazz_apiendpoint, jazz_userpass, jenkins_url,
             jenkins_userpass, apigee_host, apigee_org, apigee_prod_env, apigee_dev_env,
-            apigee_svc_prod_host, apigee_svc_dev_host, apigee_userpass):
+            apigee_svc_prod_host, apigee_svc_dev_host, apigee_userpass, accesskey, secretkey):
     click.secho('\n\nThis will install {0} functionality into your Jazz \
                 deployment'.format(featureName), fg='blue')
     click.secho('\nThis installer will use whatever AWS credentials you have configured by \
@@ -106,8 +116,8 @@ def install(region, stackprefix, jazz_apiendpoint, jazz_userpass, jenkins_url,
     apigee_userpass_list = ''.join(list(apigee_userpass)).split()
     apigee_username, apigee_password = apigee_userpass_list[0], apigee_userpass_list[1]
     install_proxy(
-        getTerraformOutputVar("apigee-lambda-user-secret-key"),
-        getTerraformOutputVar("apigee-lambda-user-id"),
+        secretkey,
+        accesskey,
         region,
         getTerraformOutputVar("apigee-lambda-gateway-func-arn"),
         apigee_host,

--- a/features/extensions/apigee/terraform/apigee-gateway-func.tf
+++ b/features/extensions/apigee/terraform/apigee-gateway-func.tf
@@ -51,53 +51,6 @@ resource "aws_iam_role_policy" "apigee-lambda-policy" {
 EOF
 }
 
-#Create a new IAM service user for Apigee to use
-#We will hand the creds for this service account off to Apigee.
-resource "aws_iam_user" "apigee-proxy-user" {
-  name = "${var.env_prefix}-jazz-apigee-proxy-lambda"
-  path = "/jazz/${var.env_prefix}/system/"
-  force_destroy = true
-}
-
-resource "aws_iam_access_key" "apigee-proxy-user-key" {
-  user = "${aws_iam_user.apigee-proxy-user.name}"
-}
-
-#The IAM user we're creating should *only* be able to exec the Apigee proxy function
-#we're creating
-resource "aws_iam_user_policy" "apigee-lambda-exec" {
-  name = "${var.env_prefix}-jazz-apigee-proxy-lambda-exec"
-  user = "${aws_iam_user.apigee-proxy-user.name}"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "lambda:InvokeFunction"
-      ],
-      "Effect": "Allow",
-      "Resource": "${var.gateway_func_arn}"
-    }
-  ]
-}
-EOF
-}
-
-output "apigee-lambda-user" {
-  value = "${aws_iam_access_key.apigee-proxy-user-key.user}"
-}
-
-#TODO This will store the Apigee user secret key in the Terraform state file on disk
-#this is not optimal but requiring the user to set up a PGP key to encrypt it is too complex for now
-output "apigee-lambda-user-secret-key" {
-  value = "${aws_iam_access_key.apigee-proxy-user-key.secret}"
-}
-
-output "apigee-lambda-user-id" {
-  value = "${aws_iam_access_key.apigee-proxy-user-key.id}"
-}
-
 output "apigee-lambda-gateway-func-arn" {
   value = "${var.gateway_func_arn}"
 }


### PR DESCRIPTION
**Requirement** 

 Use Restrictive Permissions for Stack creation

**Description** 

As part of using restrictive Permission as part of stack creation, we must ask the apigee user keys as input rather than creating it

