### PR TITLE
Utilize installed region to avoid aws configure in install box

### DIFF
--- a/installer/cli/uninstallcli.py
+++ b/installer/cli/uninstallcli.py
@@ -23,7 +23,7 @@ def uninstall(mode, aws_access_key, aws_secret_key):
     click.secho('\n\n Collecting terraform output vars from existing install...', fg='blue')
     stackprefix = get_terraform_output_var("jazzprefix")
     identity = get_terraform_output_var("jazzusername")
-
+    os.environ['AWS_DEFAULT_REGION'] = get_terraform_output_var("region")
     click.secho(
         '\nRunning destroy prep with option: {0}, prefix: {1}, and identity: {2}'
         .format(mode, stackprefix, identity), fg='green')

--- a/installer/cli/uninstallcli.py
+++ b/installer/cli/uninstallcli.py
@@ -23,15 +23,15 @@ def uninstall(mode, aws_access_key, aws_secret_key):
     click.secho('\n\n Collecting terraform output vars from existing install...', fg='blue')
     stackprefix = get_terraform_output_var("jazzprefix")
     identity = get_terraform_output_var("jazzusername")
-    os.environ['AWS_DEFAULT_REGION'] = get_terraform_output_var("region")
+    region = get_terraform_output_var("region")
     click.secho(
         '\nRunning destroy prep with option: {0}, prefix: {1}, and identity: {2}'
         .format(mode, stackprefix, identity), fg='green')
 
     if mode == "all":
-        destroyprep(stackprefix, identity, True)
+        destroyprep(stackprefix, identity, region, True)
     else:
-        destroyprep(stackprefix, identity, False)
+        destroyprep(stackprefix, identity, region, False)
 
     click.secho('\nRunning terraform destroy', fg='green')
     exec_terraform_destroy()

--- a/installer/helpers/destroy/delete_cf_dists.py
+++ b/installer/helpers/destroy/delete_cf_dists.py
@@ -1,74 +1,48 @@
-import json
-import os
-import subprocess
 import time
-from collections import OrderedDict
 
 
-def listCFDistributions(fname):
-    return subprocess.call(
-        'aws cloudfront --region ' + region + ' list-distributions >> ' + fname, shell=True)
+def listCFDistributions():
+    return cf_client.list_distributions()
 
 
-def checkCloudFrontExists(CFId, fname):
-    return subprocess.call(
-        'aws cloudfront --region ' + region + ' get-distribution-config --id ' + CFId + ' >> ' + fname,
-        shell=True)
+def checkCloudFrontExists(CFId):
+    try:
+        return cf_client.get_distribution_config(Id=CFId)
+    except Exception:
+        return False
 
 
-def getCloudFrontStatus(CFId, fname):
-    return subprocess.call(
-        'aws cloudfront --region ' + region + ' get-distribution --id ' + CFId + ' >> ' + fname,
-        shell=True)
+def getCloudFrontStatus(CFId):
+    try:
+        return cf_client.get_distribution(Id=CFId)
+    except Exception:
+        return False
 
 
 def deleteCloudFront(CFId, eTAG):
     print("\tcalling delete of CloudFront Dist ( " + CFId + " )")
-    retval = subprocess.call(
-        'aws cloudfront --region ' + region + ' delete-distribution --id ' + CFId + ' --if-match ' +
-        eTAG,
-        shell=True)
-    if (retval == 0):
+    try:
+        cf_client.delete_distribution(Id=CFId, IfMatch=eTAG)
         print("\t\tSuccessfully deleted CloudFront Distribution ( " + CFId +
               " )")
-    else:
+    except Exception:
         print("\t\tError deleting CloudFront Distribution ( " + CFId + " )")
-    return retval
 
 
-def disableCloudFront(CFId, eTAG, fname):
-    return subprocess.call(
-        'aws cloudfront --region ' + region + ' update-distribution --id ' + CFId +
-        ' --distribution-config file://' + fname + ' --if-match ' + eTAG,
-        shell=True)
-
-
-def deleteFile(filenameToDel):
+def disableCloudFront(CFId, eTAG, dconfig):
     try:
-        os.remove(filenameToDel)
-    except OSError:
-        pass
+        return cf_client.update_distribution(Id=CFId, DistributionConfig=dconfig, IfMatch=eTAG)
+    except Exception:
+        return False
 
 
-def loadJsonFromFile(fileJson):
-    fileOp = open(fileJson, 'r')
-    jsonOp = json.load(fileOp, object_pairs_hook=OrderedDict)
-    fileOp.close()
-    return jsonOp
-
-
-def delete_cf_dists(stackname, region_name, deletedists=False):
-    global region
-    region = region_name
-    fdirectory = os.getcwd()
-    fnListContent = fdirectory + "/listdist.json"
-    deleteFile(fnListContent)
+def delete_cf_dists(stackname, client, deletedists=False):
+    global cf_client
+    cf_client = client
 
     print("Fetching Cloud Front Distributions")
 
-    listCFDistributions(fnListContent)
-
-    jsonCFDists = loadJsonFromFile(fnListContent)
+    jsonCFDists = listCFDistributions()
 
     print("Done Fetching Cloud Front Distributions.")
 
@@ -78,35 +52,21 @@ def delete_cf_dists(stackname, region_name, deletedists=False):
 
     for cfDistItem in jsonCFDists['DistributionList']['Items']:
         if (cfDistItem['Origins']['Items'][0]['Id'].startswith(stackname)):
-            filename = fdirectory + cfDistItem['Id'] + ".json"
-            filestatus = fdirectory + cfDistItem['Id'] + "-status.json"
-            deleteFile(filename)
-            deleteFile(filestatus)
 
-            retcode = checkCloudFrontExists(cfDistItem['Id'], filename)
+            cfGetConfigResp = checkCloudFrontExists(cfDistItem['Id'])
             cfReadyToDelete = False
 
-            if (str(retcode).__eq__("0")):
-                jsonCFGetConfig = loadJsonFromFile(filename)
+            if (cfGetConfigResp is not False):
+                jsonCFGetConfig = cfGetConfigResp
 
                 if (jsonCFGetConfig['DistributionConfig']['Enabled'] is True):
                     jsonCFGetConfig['DistributionConfig']['Enabled'] = False
                     print("Found Stack CF Distribution  ( " +
                           cfDistItem['Id'] + " ) that needs to be disabled")
-                    fileDistDisable = cfDistItem['Id'] + ".json"
-                    deleteFile(fileDistDisable)
-
-                    with open(fileDistDisable, 'a') as the_file:
-                        the_file.write(
-                            json.dumps(
-                                jsonCFGetConfig['DistributionConfig'],
-                                sort_keys=False,
-                                indent=4))
-
                     retval = disableCloudFront(cfDistItem['Id'],
                                                jsonCFGetConfig['ETag'],
-                                               fileDistDisable)
-                    if (retval == 0):
+                                               jsonCFGetConfig['DistributionConfig'])
+                    if (retval is not False):
                         print("Dist ( " + cfDistItem['Id'] +
                               " ) Disable has been called successfully..... ")
                     else:
@@ -129,20 +89,13 @@ def delete_cf_dists(stackname, region_name, deletedists=False):
     print("Starting deletion of CF Distributions for stack: {0}".format(
         stackname))
 
-    jsonCFDists = loadJsonFromFile(fnListContent)
-
     for cfDistItem in jsonCFDists['DistributionList']['Items']:
         if (cfDistItem['Origins']['Items'][0]['Id'].startswith(stackname)):
-            filename = fdirectory + cfDistItem['Id'] + ".json"
-            filestatus = fdirectory + cfDistItem['Id'] + "-status.json"
-            deleteFile(filename)
-            deleteFile(filestatus)
-
-            retcode = checkCloudFrontExists(cfDistItem['Id'], filename)
+            cfGetConfigResp = checkCloudFrontExists(cfDistItem['Id'])
             cfReadyToDelete = False
 
-            if (str(retcode).__eq__("0")):
-                jsonCFGetConfig = loadJsonFromFile(filename)
+            if (cfGetConfigResp is not False):
+                jsonCFGetConfig = cfGetConfigResp
                 print("\tStarted on CloudFront Distribution ( " +
                       cfDistItem['Id'] + " ) which is enabled==" +
                       str(jsonCFGetConfig['DistributionConfig']['Enabled']))
@@ -152,23 +105,11 @@ def delete_cf_dists(stackname, region_name, deletedists=False):
                         "\t\tFirst Disabling the Cloud Front Distribution ( " +
                         cfDistItem['Id'] + " ) set enabled==" + str(
                             jsonCFGetConfig['DistributionConfig']['Enabled']))
-                    cfDistFile = cfDistItem['Id'] + ".json"
-                    deleteFile(cfDistFile)
-
-                    with open(cfDistFile, 'a') as the_file:
-                        the_file.write(
-                            json.dumps(
-                                jsonCFGetConfig['DistributionConfig'],
-                                sort_keys=False,
-                                indent=4))
-
                     disableCloudFront(cfDistItem['Id'],
-                                      jsonCFGetConfig['ETag'], cfDistFile)
+                                      jsonCFGetConfig['ETag'], jsonCFGetConfig['DistributionConfig'])
 
                     while (cfReadyToDelete is False):
-                        deleteFile(filestatus)
-                        getCloudFrontStatus(cfDistItem['Id'], filestatus)
-                        valuesStatus = loadJsonFromFile(filestatus)
+                        valuesStatus = getCloudFrontStatus(cfDistItem['Id'])
                         if (valuesStatus['Distribution']['Status'] ==
                                 "InProgress"):
                             cfReadyToDelete = False
@@ -181,18 +122,11 @@ def delete_cf_dists(stackname, region_name, deletedists=False):
                         else:
                             cfReadyToDelete = True
 
-                    retval = deleteCloudFront(cfDistItem['Id'],
-                                              jsonCFGetConfig['ETag'])
+                    deleteCloudFront(cfDistItem['Id'], jsonCFGetConfig['ETag'])
 
                 else:
                     while (cfReadyToDelete is False):
-                        try:
-                            os.remove(filestatus)
-                        except OSError:
-                            pass
-
-                        getCloudFrontStatus(cfDistItem['Id'], filestatus)
-                        valuesStatus = loadJsonFromFile(filestatus)
+                        valuesStatus = getCloudFrontStatus(cfDistItem['Id'])
                         if (valuesStatus['Distribution']['Status'] ==
                                 "InProgress"):
                             cfReadyToDelete = False
@@ -205,8 +139,7 @@ def delete_cf_dists(stackname, region_name, deletedists=False):
                         else:
                             cfReadyToDelete = True
 
-                    retval = deleteCloudFront(cfDistItem['Id'],
-                                              jsonCFGetConfig['ETag'])
+                    deleteCloudFront(cfDistItem['Id'], jsonCFGetConfig['ETag'])
 
     print("Completed deleting of CF Distributions for stack {0}".format(
         stackname))

--- a/installer/helpers/destroy/delete_cf_dists.py
+++ b/installer/helpers/destroy/delete_cf_dists.py
@@ -7,25 +7,25 @@ from collections import OrderedDict
 
 def listCFDistributions(fname):
     return subprocess.call(
-        'aws cloudfront list-distributions >> ' + fname, shell=True)
+        'aws cloudfront --region ' + region + ' list-distributions >> ' + fname, shell=True)
 
 
 def checkCloudFrontExists(CFId, fname):
     return subprocess.call(
-        'aws cloudfront get-distribution-config --id ' + CFId + ' >> ' + fname,
+        'aws cloudfront --region ' + region + ' get-distribution-config --id ' + CFId + ' >> ' + fname,
         shell=True)
 
 
 def getCloudFrontStatus(CFId, fname):
     return subprocess.call(
-        'aws cloudfront get-distribution --id ' + CFId + ' >> ' + fname,
+        'aws cloudfront --region ' + region + ' get-distribution --id ' + CFId + ' >> ' + fname,
         shell=True)
 
 
 def deleteCloudFront(CFId, eTAG):
     print("\tcalling delete of CloudFront Dist ( " + CFId + " )")
     retval = subprocess.call(
-        'aws cloudfront delete-distribution --id ' + CFId + ' --if-match ' +
+        'aws cloudfront --region ' + region + ' delete-distribution --id ' + CFId + ' --if-match ' +
         eTAG,
         shell=True)
     if (retval == 0):
@@ -38,7 +38,7 @@ def deleteCloudFront(CFId, eTAG):
 
 def disableCloudFront(CFId, eTAG, fname):
     return subprocess.call(
-        'aws cloudfront update-distribution --id ' + CFId +
+        'aws cloudfront --region ' + region + ' update-distribution --id ' + CFId +
         ' --distribution-config file://' + fname + ' --if-match ' + eTAG,
         shell=True)
 
@@ -57,7 +57,9 @@ def loadJsonFromFile(fileJson):
     return jsonOp
 
 
-def delete_cf_dists(stackname, deletedists=False):
+def delete_cf_dists(stackname, region_name, deletedists=False):
+    global region
+    region = region_name
     fdirectory = os.getcwd()
     fnListContent = fdirectory + "/listdist.json"
     deleteFile(fnListContent)

--- a/installer/helpers/destroy/delete_event_source_mapping.py
+++ b/installer/helpers/destroy/delete_event_source_mapping.py
@@ -2,7 +2,7 @@ import subprocess
 import json
 
 
-def delete_event_source_mapping(stackName):
+def delete_event_source_mapping(stackName, region):
     """
         This method will list out the function mapping and
         then delete the event source mapping
@@ -17,7 +17,7 @@ def delete_event_source_mapping(stackName):
         print("Listing Event source mapping for function " + event_source_function)
         list_event_output = subprocess.check_output([
             "aws", "lambda", "list-event-source-mappings", "--function-name",
-            event_source_function
+            event_source_function, "--region", region
         ])
         print(list_event_output)
 
@@ -30,7 +30,7 @@ def delete_event_source_mapping(stackName):
 
             # Deleting the Event source mapping
             delete_event_output = subprocess.check_output([
-                "aws", "lambda", "delete-event-source-mapping", "--uuid", uuid
+                "aws", "lambda", "delete-event-source-mapping", "--uuid", uuid, "--region", region
             ])
             print(delete_event_output)
         else:

--- a/installer/helpers/destroy/delete_event_source_mapping.py
+++ b/installer/helpers/destroy/delete_event_source_mapping.py
@@ -1,8 +1,4 @@
-import subprocess
-import json
-
-
-def delete_event_source_mapping(stackName, region):
+def delete_event_source_mapping(stackName, client):
     """
         This method will list out the function mapping and
         then delete the event source mapping
@@ -15,23 +11,18 @@ def delete_event_source_mapping(stackName, region):
 
     try:
         print("Listing Event source mapping for function " + event_source_function)
-        list_event_output = subprocess.check_output([
-            "aws", "lambda", "list-event-source-mappings", "--function-name",
-            event_source_function, "--region", region
-        ])
+        list_event_output = client.list_event_source_mappings(
+            FunctionName=event_source_function,
+        )
         print(list_event_output)
 
-        # Parser the json payload
-        json_parse = json.loads(list_event_output)
-        if json_parse is not None and len(
-                json_parse['EventSourceMappings']) > 0:
-            uuid = json_parse['EventSourceMappings'][0]['UUID']
+        if list_event_output is not None and len(
+                list_event_output['EventSourceMappings']) > 0:
+            uuid = list_event_output['EventSourceMappings'][0]['UUID']
             print("uuid " + uuid)
 
             # Deleting the Event source mapping
-            delete_event_output = subprocess.check_output([
-                "aws", "lambda", "delete-event-source-mapping", "--uuid", uuid, "--region", region
-            ])
+            delete_event_output = client.delete_event_source_mapping(UUID=uuid)
             print(delete_event_output)
         else:
             print("No Event source mapping found")

--- a/installer/helpers/destroy/delete_platform_services.py
+++ b/installer/helpers/destroy/delete_platform_services.py
@@ -6,7 +6,7 @@ import os.path
 
 def checkCFServiceAvailable(servicename):
     return subprocess.call(
-        "aws cloudformation list-stack-resources --stack-name " + servicename,
+        "aws cloudformation list-stack-resources --stack-name " + servicename + " --region " + region,
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT)
@@ -14,7 +14,7 @@ def checkCFServiceAvailable(servicename):
 
 def deleteCFService(servicename):
     return subprocess.call(
-        "aws cloudformation delete-stack --stack-name " + servicename,
+        "aws cloudformation delete-stack --stack-name " + servicename + " --region " + region,
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT)
@@ -22,7 +22,7 @@ def deleteCFService(servicename):
 
 def getServicesList():
     return subprocess.call(
-        'aws cloudformation list-stacks --stack-status-filter \
+        'aws cloudformation list-stacks --region ' + region + ' --stack-status-filter \
         "CREATE_IN_PROGRESS" "CREATE_FAILED" "CREATE_COMPLETE" "UPDATE_IN_PROGRESS" "UPDATE_COMPLETE" \
         >> listservice.json',
         shell=True)
@@ -43,7 +43,9 @@ def deleteCloudFormationService(service_name):
         print('Error service not found::' + service_name)
 
 
-def delete_platform_services(stackname, deleteClientServices=False):
+def delete_platform_services(stackname, region_name, deleteClientServices=False):
+    global region
+    region = region_name
     print("\r\nStarting deletion of micro services\r\n\r\n")
 
     # Delete user services Cloud formations

--- a/installer/helpers/destroy/delete_platform_services.py
+++ b/installer/helpers/destroy/delete_platform_services.py
@@ -1,68 +1,49 @@
-import json
-import subprocess
-import os
-import os.path
-
-
 def checkCFServiceAvailable(servicename):
-    return subprocess.call(
-        "aws cloudformation list-stack-resources --stack-name " + servicename + " --region " + region,
-        shell=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT)
+    try:
+        return cform_client.list_stack_resources(StackName=servicename)
+    except Exception:
+        return False
 
 
 def deleteCFService(servicename):
-    return subprocess.call(
-        "aws cloudformation delete-stack --stack-name " + servicename + " --region " + region,
-        shell=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT)
+    try:
+        return cform_client.delete_stack(StackName=servicename)
+    except Exception:
+        return False
 
 
 def getServicesList():
-    return subprocess.call(
-        'aws cloudformation list-stacks --region ' + region + ' --stack-status-filter \
-        "CREATE_IN_PROGRESS" "CREATE_FAILED" "CREATE_COMPLETE" "UPDATE_IN_PROGRESS" "UPDATE_COMPLETE" \
-        >> listservice.json',
-        shell=True)
+    paginator = cform_client.get_paginator('list_stacks')
+    return paginator.paginate(StackStatusFilter=["CREATE_IN_PROGRESS",
+                                                 "CREATE_FAILED",
+                                                 "CREATE_COMPLETE",
+                                                 "UPDATE_IN_PROGRESS",
+                                                 "UPDATE_COMPLETE"])
 
 
 def deleteCloudFormationService(service_name):
     return_code = checkCFServiceAvailable(service_name)
-    if return_code == 0:
+    if return_code is not False:
         print("Service::" + service_name +
               ": exists. Service deletion started.........")
         delete_return_code = deleteCFService(service_name)
-        if delete_return_code == 0:
+        if delete_return_code is not False:
             print("\tSuccessfully deleted service " + service_name)
         else:
-            print("\tError while deleting service " + service_name +
-                  " errorcode=" + delete_return_code)
+            print("\tError while deleting service " + service_name)
     else:
         print('Error service not found::' + service_name)
 
 
-def delete_platform_services(stackname, region_name, deleteClientServices=False):
-    global region
-    region = region_name
+def delete_platform_services(stackname, client, deleteClientServices=False):
+    global cform_client
+    cform_client = client
     print("\r\nStarting deletion of micro services\r\n\r\n")
 
     # Delete user services Cloud formations
-    fname = 'listservice.json'
-    if os.path.isfile(fname):
-        os.remove(fname)
-
     valresp = getServicesList()
-    if (valresp != 0):
-        exit(1)
-
-    jsonFile = open(fname, 'r')
-    values = json.load(jsonFile)
-    jsonFile.close()
-
-    ss = values['StackSummaries']
-
-    for item in ss:
-        if (item['StackName'].startswith(stackname)):
-            deleteCloudFormationService(item['StackName'])
+    for page in valresp:
+        stack = page['StackSummaries']
+        for output in stack:
+            if (output['StackName'].startswith(stackname)):
+                deleteCloudFormationService(output['StackName'])

--- a/installer/helpers/destroyprep.py
+++ b/installer/helpers/destroyprep.py
@@ -7,6 +7,9 @@ from installer.helpers.destroy.delete_cf_dists import delete_cf_dists
 def destroyprep(stackname, identity, region, all=False):
     # Delete the identity policy  - Created in terraform/scripts/ses.sh
     client = boto3.client('ses', region_name=region)
+    cloudfront_client = boto3.client('cloudfront', region_name=region)
+    lambda_client = boto3.client('lambda', region_name=region)
+    cloudformation_client = boto3.client('cloudformation', region_name=region)
     client.delete_identity_policy(
         Identity=identity,
         PolicyName="Policy-{0}".format(stackname)
@@ -15,9 +18,9 @@ def destroyprep(stackname, identity, region, all=False):
     print("Destroy all: {0} for stack {1}".format(all, stackname))
     # run python scripts to teardown
     if all:
-        delete_event_source_mapping(stackname, region)
-        delete_platform_services(stackname, region, True)
-        delete_cf_dists(stackname, region, True)
+        delete_event_source_mapping(stackname, lambda_client)
+        delete_platform_services(stackname, cloudformation_client, True)
+        delete_cf_dists(stackname, cloudfront_client, True)
     else:
-        delete_event_source_mapping(stackname, region)
-        delete_platform_services(stackname, region, False)
+        delete_event_source_mapping(stackname, lambda_client)
+        delete_platform_services(stackname, cloudformation_client, False)

--- a/installer/helpers/destroyprep.py
+++ b/installer/helpers/destroyprep.py
@@ -4,9 +4,9 @@ from installer.helpers.destroy.delete_platform_services import delete_platform_s
 from installer.helpers.destroy.delete_cf_dists import delete_cf_dists
 
 
-def destroyprep(stackname, identity, all=False):
+def destroyprep(stackname, identity, region, all=False):
     # Delete the identity policy  - Created in terraform/scripts/ses.sh
-    client = boto3.client('ses')
+    client = boto3.client('ses', region_name=region)
     client.delete_identity_policy(
         Identity=identity,
         PolicyName="Policy-{0}".format(stackname)
@@ -15,9 +15,9 @@ def destroyprep(stackname, identity, all=False):
     print("Destroy all: {0} for stack {1}".format(all, stackname))
     # run python scripts to teardown
     if all:
-        delete_event_source_mapping(stackname)
-        delete_platform_services(stackname, True)
-        delete_cf_dists(stackname, True)
+        delete_event_source_mapping(stackname, region)
+        delete_platform_services(stackname, region, True)
+        delete_cf_dists(stackname, region, True)
     else:
-        delete_event_source_mapping(stackname)
-        delete_platform_services(stackname, False)
+        delete_event_source_mapping(stackname, region)
+        delete_platform_services(stackname, region, False)

--- a/ubuntu-provision.sh
+++ b/ubuntu-provision.sh
@@ -103,7 +103,7 @@ function install_packages () {
 
   # Update apt repo.
   sudo apt update
-  alias python=$PYEXE
+  alias python='echo $PYEXE'
   spin_wheel $! "Update apt repo"
 
   # Install git
@@ -177,7 +177,7 @@ function install_packages () {
   pip3 install virtualenv
   sudo apt-get install -y python3-venv >> "$LOG_FILE" &
   spin_wheel $! "Installing virtualenv"
-  
+
   $PYEXE -m venv jazzenv >> "$LOG_FILE" &
   spin_wheel $! "Creating virtualenv"
 
@@ -227,6 +227,7 @@ while [ $# -gt 0 ] ; do
 
     -ib|--installer-branch)
       shift
+      # shellcheck disable=SC2236
       if [ ! -z "$1" ] ; then
         JAZZ_INSTALLER_BRANCH="$1"
       else

--- a/ubuntu-provision.sh
+++ b/ubuntu-provision.sh
@@ -1,0 +1,276 @@
+#!/bin/bash
+#
+# File: ubuntu-provision.sh
+# Description: Installs jazz prerequisites on a Ubuntu 18.04.2 LTS ec2-instance.
+#              if you already have the prerequisites installed, just run Installer.py
+#              directly from the from the cloned jazz-installer folder.
+# Variables section
+
+# Disable shellcheck warnings about sudo and output redirection, doesn't apply here
+# shellcheck disable=SC2024
+
+#TODO consider using pyenv
+
+TERRAFORM_URL="https://releases.hashicorp.com/terraform/0.11.13/terraform_0.11.13_linux_amd64.zip"
+ATLASSIAN_CLI_URL="https://bobswift.atlassian.net/wiki/download/attachments/16285777/atlassian-cli-6.7.1-distribution.zip"
+INSTALLER_GITHUB_URL="https://github.com/tmobile/jazz-installer.git"
+
+# Installation directory
+INSTALL_DIR=$(pwd)
+
+#Since Ubuntu 18.04.2 use default Python3
+PYEXE='python3'
+
+# Log file to record the installation logs
+LOG_FILE_NAME=provision_setup.out
+LOG_FILE=$(realpath "$INSTALL_DIR"/"$LOG_FILE_NAME")
+JAZZ_INSTALLER_BRANCH="master"
+
+# Default verbosity of the installation
+VERBOSE=0
+
+NC='\033[0m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+
+print_info()
+{
+  # shellcheck disable=SC2059
+  printf "\\r${GREEN}$1${NC}\\n" 1>&3 2>&4
+}
+
+print_error()
+{
+  # shellcheck disable=SC2059
+  printf "\\r${RED}$1${NC}\\n" 1>&3 2>&4
+}
+
+#Spin wheel
+function spin_wheel () {
+  pid=$1 # Process Id of the previous running command
+  message=$2
+  spin='-\|/'
+  printf "\\r%s...." "$message" 1>&3 2>&4
+  i=0
+
+  while ps -p "$pid" > /dev/null
+  do
+    i=$(( (i+1) %4 ))
+    # shellcheck disable=SC2059
+    printf "\\r${GREEN}$message....${spin:$i:1}" 1>&3 2>&4
+    sleep .05
+  done
+
+  while s=$(ps -p "$pid" -o s=) && [[ "$s" && "$s" != 'Z' ]]; do
+    sleep 1
+  done
+  exitcode=$?
+  if [ $exitcode -gt 0 ]
+  then
+    print_error "$message....Failed"
+    exit
+  else
+    print_info "$message....Completed"
+
+  fi
+}
+trap 'printf "${RED}\nCancelled....\n${NC}" 1>&3 2>&4; exit' 2
+trap '' SIGTSTP
+
+function install_packages () {
+  # Download and Installing Softwares required for Jazz ubuntu-provision
+  # Java JDK
+  # Unzip
+  # Terraform
+  # Atlassian CLI
+  # Python36
+  # Python requirements from requirements.txt
+
+  #Fork output redirection so we can control output if VERBOSE is set
+  exec 3>&1
+  exec 4>&2
+
+  # print verbosity mode during installation
+  if [ "$1" == 1 ]; then
+    print_info "You have started the installer in verbose mode" 1>&3 2>&4
+  elif [ "$1" == 0 ]; then
+    # Redirecting the stdout and stderr to /dev/null for non-verbose installation
+    exec 1>/dev/null
+    exec 2>/dev/null
+    print_info "You have started the installer in non-verbose mode" 1>&3 2>&4
+  fi
+  print_info "You may view the detailed installation logs at $LOG_FILE" 1>&3 2>&4
+
+  # Update apt repo.
+  sudo apt update
+  alias python=$PYEXE
+  spin_wheel $! "Update apt repo"
+
+  # Install git
+  if command -v git > /dev/null; then
+    print_info "Git already installed, using it"
+  else
+    sudo apt install -y git >> "$LOG_FILE" &
+    spin_wheel $! "Installing git"
+  fi
+
+  # Download and Install java
+  if command -v java > /dev/null; then
+    print_info "Java already installed, using it"
+  else
+    sudo apt install -y openjdk-8-jdk >> "$LOG_FILE" &
+    export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/
+    spin_wheel $! "Installing Java 1.8"
+  fi
+
+  #TODO is this required? it shouldn't be
+  # Download and Install jq
+  if command -v jq > /dev/null; then
+    print_info "JQ already installed, using it"
+  else
+    sudo apt  install -y jq >> "$LOG_FILE" &
+    spin_wheel $! "Installing jq"
+  fi
+
+  # Download and Install unzip
+  if command -v unzip > /dev/null; then
+    print_info "Unzip already installed, using it"
+  else
+    sudo apt install -y unzip >> "$LOG_FILE" &
+    spin_wheel $! "Installing unzip"
+  fi
+
+  # Create a temporary folder .
+  # Here we will have all the temporary files needed and delete it at the end
+  sudo rm -rf "$INSTALL"_DIR/jazz_tmp
+  mkdir "$INSTALL_DIR"/jazz_tmp
+
+  #Download and Install Terraform
+  curl -v -L "$TERRAFORM_URL" -o "$INSTALL_DIR"/jazz_tmp/terraform.zip >> "$LOG_FILE" &
+  spin_wheel $! "Downloading terraform"
+  sudo unzip -o "$INSTALL_DIR"/jazz_tmp/terraform.zip -d /usr/bin >> "$LOG_FILE" &
+  spin_wheel $! "Installing terraform"
+
+  #Downloading and Install atlassian-cli
+  curl -L "$ATLASSIAN_CLI_URL" -o "$INSTALL_DIR"/jazz_tmp/atlassian-cli-6.7.1-distribution.zip >> "$LOG_FILE" &
+  spin_wheel $! "Downloading atlassian-cli"
+  unzip -o "$INSTALL_DIR"/jazz_tmp/atlassian-cli-6.7.1-distribution.zip -d "$INSTALL_DIR"/jazz_tmp/ >> "$LOG_FILE" &
+  spin_wheel $! "Fetching atlassian-cli"
+
+  # Installing python36+
+  if command -v $PYEXE > /dev/null; then
+    print_info "python already installed, using it"
+  else
+    sudo apt install -y python3.6 >> "$LOG_FILE" &
+    spin_wheel $! "Installing python36"
+  fi
+
+  #Download and install pip
+  if command -v $PYEXE -m pip > /dev/null; then
+    print_info "pip already installed, using it"
+  else
+    sudo apt install -y python3-pip >> "$LOG_FILE" &
+    spin_wheel $! "Installing pip"
+    alias pip=pip3
+  fi
+
+  pip3 install virtualenv
+  sudo apt-get install -y python3-venv >> "$LOG_FILE" &
+  spin_wheel $! "Installing virtualenv"
+  
+  $PYEXE -m venv jazzenv >> "$LOG_FILE" &
+  spin_wheel $! "Creating virtualenv"
+
+  # shellcheck disable=SC1091
+  source jazzenv/bin/activate
+
+  #Get Jazz installer code base
+  if [ -z "$JAZZ_INSTALLER_BRANCH" ]; then
+    echo "Jazz branch to clone"
+    print_info "Skipping installer repo clone based on CLI flag"
+  else
+    sudo rm -rf jazz-installer
+    git clone -b "$JAZZ_INSTALLER_BRANCH" "$INSTALLER_GITHUB_URL" --depth 1 >> "$LOG_FILE" &
+    spin_wheel $! "Fetching jazz-installer repo"
+  fi
+
+  # If you're running this standalone, you'll need the subfolder
+  if [ -e jazz-installer/requirements.txt ]
+  then
+    pip install -r jazz-installer/requirements.txt >> "$LOG_FILE" &
+    spin_wheel $! "Installing pip dependencies"
+  else
+    pip install -r requirements.txt >> "$LOG_FILE" &
+    spin_wheel $! "Installing pip dependencies"
+  fi
+
+  #Undo output redirection and close unused file descriptors.
+  exec 1>&3 3>&-
+  exec 2>&4 4>&-
+}
+
+# Running the selector
+while [ $# -gt 0 ] ; do
+  case "$1" in
+    -h|--help)
+      echo "Installs jazz prerequisites on a ubuntu ec2-instance."
+      echo ""
+      echo "./ubuntu-provision.sh [options]"
+      echo ""
+      echo "options:"
+      echo "-ib, --installer-branch                     [optional] ubuntu-provision repo branch to use. Defaults to 'master'"
+      echo "-nc, --no-clone                             [optional] Skip cloning the jazz-installer repo into the current directory. Default: repo is cloned."
+      echo "-v, --verbose 1|0                           [optional] Enable/Disable verbose ubuntu-provision logs. Default:0(Disabled)"
+      echo "-t, --tags Key=stackName,Value=production   [optional] Specify as space separated key/value pairs"
+      echo "-h, --help                                  [optional] Describe help"
+      exit 0 ;;
+
+    -ib|--installer-branch)
+      shift
+      if [ ! -z "$1" ] ; then
+        JAZZ_INSTALLER_BRANCH="$1"
+      else
+        echo "No arguments supplied for installer branch name."
+        echo "Usage: ./ubuntu-provision.sh -ib installer_branch_name"
+        exit 1
+      fi
+      shift ;;
+
+    -nc|--no-clone)
+      shift
+      JAZZ_INSTALLER_BRANCH=''
+      shift ;;
+
+    -v|--verbose)
+      shift
+      if [[ ("$#" -gt 0) && ("$1" == "1") ]] || [[ ("$#" -gt 0) && ("$1" == "0") ]] ; then
+        VERBOSE="$1"
+      else
+        echo "Please specify 1 or 0 for verbosity. Enable/Disable verbose ubuntu-provision logs. Default:0(Disabled)"
+        echo "Usage: ./ubuntu-provision --verbose 1"
+        exit 1
+      fi
+      shift ;;
+
+    -t|--tags)
+      shift
+      while [ "$#" -gt 0 ] ; do
+        if [[ "$1" =~ Key=.*,Value=.* ]] && [[ ! "$1" =~ ";" ]] ; then
+          arr+=("$1")
+        elif [[ $1 == -* ]] ; then break
+        else
+          echo "Please specify tags in format: Key=stackName,Value=production"
+          echo "Usage: ./ubuntu-provision --tags Key=stackName,Value=production Key=department,Value=devops"
+          exit 1
+        fi
+        shift
+      done ;;
+
+    *)
+      echo "Invalid flag!"
+      echo "Please run './ubuntu-provision.sh -h' to see all the available options."
+      exit 1 ;;
+  esac
+done
+
+install_packages "$VERBOSE"


### PR DESCRIPTION
**Requirement**

1. Utilize installed region to avoid aws configure in install box
2. Replace awscli commands using boto3

**Description**

boto3 expects region parameter either through configured aws or as an environment. So this will utilize the installed region pass by value.