### PR TITLE
Added condition to check python3 exists or not

### DIFF
--- a/installer/terraform/provisioners/cookbooks/jenkins/recipes/installpython3.rb
+++ b/installer/terraform/provisioners/cookbooks/jenkins/recipes/installpython3.rb
@@ -1,11 +1,15 @@
 # Install python3 runtime
 bash 'install-python3' do
   code <<-EOH
-  yum install -y https://centos7.iuscommunity.org/ius-release.rpm
-  rm -fr /var/cache/yum/*
-  yum clean all
-  yum update
-  yum install -y python36u python36u-libs python36u-devel python36u-pip
+  version=$(python3 -V 2>&1 | grep -Po '(?<=Python )(.+)')
+  if [[ -z "$version" ]]
+  then
+      yum install -y https://centos7.iuscommunity.org/ius-release.rpm
+      rm -fr /var/cache/yum/*
+      yum clean all
+      yum update
+      yum install -y python36u python36u-libs python36u-devel python36u-pip
+  fi  
   EOH
 end
 


### PR DESCRIPTION
For scenario1, Chef bash command failed when python3 is already installed. Added condition to restrict that. 

> python3-devel-3.6.8-10.el7.x86_64 conflicts with file from package python36u-devel-3.6.8-1.el7.ius.x86_6

4