### PR TITLE
Automated script to delete lambda vpc enis in available state

### DIFF
--- a/installer/terraform/commands.tf
+++ b/installer/terraform/commands.tf
@@ -62,3 +62,7 @@ variable "config_cmd" {
   type = "string"
   default = "./scripts/config.py"
 }
+variable "cleanEni_cmd" {
+  type = "string"
+  default = "./scripts/clean_lambda_eni.py"
+}

--- a/installer/terraform/scripts/clean_lambda_eni.py
+++ b/installer/terraform/scripts/clean_lambda_eni.py
@@ -1,0 +1,49 @@
+import boto3
+import sys
+import time
+
+
+def cleanup(client, vpc_id, sg_id):
+    in_use_found = False
+    try:
+        response = client.describe_network_interfaces(
+            Filters=[
+                {
+                    'Name': 'vpc-id',
+                    'Values': [
+                        str(vpc_id),
+                    ]
+                },
+                {
+                    'Name': 'group-id',
+                    'Values': [
+                        str(sg_id),
+                    ]
+                },
+            ],
+        )
+        for item in response['NetworkInterfaces']:
+            if "AWS Lambda VPC ENI" in item['Description']:
+                if item['Status'] == 'in-use':
+                    in_use_found = True
+                if item['Status'] == 'available':
+                    # delete the ENI
+                    print("Item to delete: " + str(item['NetworkInterfaceId']))
+                    response = client.delete_network_interface(
+                         NetworkInterfaceId=str(item['NetworkInterfaceId'])
+                    )
+        if in_use_found:
+            print("Still In use ENIs found")
+            time.sleep(30)
+            cleanup(client, vpc_id, sg_id)
+        else:
+            return True
+    except Exception as message:
+        print(message)
+        time.sleep(30)
+        cleanup(client, vpc_id, sg_id)
+
+
+if __name__ == u"__main__":
+    client = boto3.client('ec2')
+    cleanup(client, sys.argv[1], sys.argv[2])

--- a/installer/terraform/vpc_subnet.tf
+++ b/installer/terraform/vpc_subnet.tf
@@ -211,6 +211,10 @@ resource "aws_subnet" "subnet_for_ecs_private" {
   availability_zone = "${element(slice(data.aws_availability_zones.available.names, 0, 2), count.index)}"
   cidr_block        = "${cidrsubnet(data.aws_vpc.vpc_data.cidr_block, ceil(log(4 * 2, 2)), 2 + count.index)}"
   tags = "${merge(var.private_ref_tag, var.additional_tags, local.common_tags)}"
+  provisioner "local-exec" {
+    when    = "destroy"
+    command = "python ${var.cleanEni_cmd} ${data.aws_vpc.vpc_data.id} ${aws_security_group.vpc_sg.id}"
+  }
 }
 
 resource "aws_route_table" "privateroute" {


### PR DESCRIPTION
**Description**
There is a known issue with the ENI's created by lambda function that are using the new improved VPC networking model for AWS Lambda function. ie the ENIs created by the Lambda function will be in  available state after the detached state. The solution is to delete the ENIs manually.

https://aws.amazon.com/blogs/compute/announcing-improved-vpc-networking-for-aws-lambda-functions/
https://aws.amazon.com/blogs/compute/update-issue-affecting-hashicorp-terraform-resource-deletions-after-the-vpc-improvements-to-aws-lambda/

**Change**

Automate the terraform subnet destroy through creating a script that will make Describe Network interface API call filtering through the VPC ID and Security Group ID that would describe the ENIs part of the VPC and if the Description contains Lambda function ENI and the Status for ENI is in "available" state, it will execute the Delete Network Interface API call.