### PR TITLE
MultiAccount Uninstall Does Not Delete Accounts From DB Config

### DIFF
--- a/features/extensions/multiaccount/README.md
+++ b/features/extensions/multiaccount/README.md
@@ -84,6 +84,8 @@ cd JAZZ_INSTALLER_DIRECTORY/features
 python Multiaccount.py uninstall
                     --jenkins_url JENKINSURL
                     --jenkins_userpass JENKINSUSER JENKINSPASSWORD
+                    --jazz_apiendpoint JAZZ_APIENDPOINT
+                    --jazz_userpass JAZZADMIN JAZZPASSWORD
                     --account-details all
 ```
 Note: account-details can be 123XXXXX, 234XXXXX etc
@@ -97,5 +99,7 @@ python Multiaccount.py uninstall
 # Enter the missing input params
 Jenkins url:
 Jenkins userpass [()]:
+Jazz apiendpoint:
+Jazz userpass [()]:
 Account details [all]:
 ```

--- a/features/extensions/multiaccount/uninstall.py
+++ b/features/extensions/multiaccount/uninstall.py
@@ -2,7 +2,8 @@ import click
 import requests
 
 from retrying import retry
-from utils.jenkins import startJobwithInputs
+from utils.jenkins import startJobwithInputs, deleteCredential
+from utils.api_config import get_config, delete_config
 
 
 featureName = "MultiAccount"
@@ -22,19 +23,63 @@ featureName = "MultiAccount"
     of the jenkins separated by a space',
     prompt=True)
 @click.option(
+    "--jazz_apiendpoint",
+    help='Specify the Jazz Endpoint',
+    prompt=True
+)
+@click.option(
+    '--jazz_userpass',
+    nargs=2,
+    required=True,
+    help='Provide the username and password \
+    of the jazz application separated by a space',
+    prompt=True)
+@click.option(
     "--account_details",
     help='Specify the Accounts to delete (Empty will delete all)',
     default='all',
     prompt=True
 )
-def uninstall(jenkins_url, jenkins_userpass, account_details):
+def uninstall(jenkins_url, jenkins_userpass, jazz_apiendpoint, jazz_userpass, account_details):
     click.secho('\n\nThis will remove {0} functionality from your Jazz deployment'.format(featureName), fg='blue')
     jenkins_userpass_list = ''.join(list(jenkins_userpass)).split()
     jenkins_username, jenkins_password = jenkins_userpass_list[0], jenkins_userpass_list[1]
+    jazz_userpass_list = ''.join(list(jazz_userpass)).split()
+    jazz_username, jazz_password = jazz_userpass_list[0], jazz_userpass_list[1]
     job = "delete-resources"
     startJobwithInputs(jenkins_url, jenkins_username, jenkins_password, job, account_details)
     if jenkins_job_status(job, jenkins_username, jenkins_password, jenkins_url):
         print("Job Executed Successfully")
+        get_configjson = get_config(jazz_username, jazz_password, jazz_apiendpoint)
+        account_info = get_configjson['data']['config']['AWS']['ACCOUNTS']
+        primary_account = get_configjson['data']['config']['AWS']['DEFAULTS']['ACCOUNTID']
+        primary_region = get_configjson['data']['config']['AWS']['DEFAULTS']['REGION']
+        finalAccounts = []
+        if (account_details == "" or account_details == "all"):
+            finalAccounts = account_info
+        else:
+            input_list = [x.strip() for x in account_details.split(',')]
+            for awsAccount in account_info:
+                accountId = awsAccount['ACCOUNTID']
+                if (accountId in input_list):
+                    finalAccounts.append(awsAccount)
+        if len(finalAccounts) > 0:
+            for index, account in enumerate(finalAccounts):
+                if account['ACCOUNTID'] != primary_account:
+                    print("DELETING - " + account['ACCOUNTID'])
+                    query_url = '?path=AWS.ACCOUNTS&id=ACCOUNTID&value=%s' % (account['ACCOUNTID'])
+                    delete_config(jazz_username, jazz_password, jazz_apiendpoint, query_url)
+                    deleteCredential(jenkins_url, jenkins_username,
+                                     jenkins_password, 'MultiAccount' + account['ACCOUNTID'])
+                else:
+                    allregions = account["REGIONS"]
+                    for awsregion in allregions:
+                        if awsregion['REGION'] != primary_region:
+                            print("DELETING NON PRIMARY REGION:" + awsregion['REGION'] +
+                                  " OF ACCOUNT: " + account['ACCOUNTID'])
+                            query_url = '?path=AWS.ACCOUNTS.' + str(index) +\
+                                        '.REGIONS&id=REGION&value=%s' % (awsregion['REGION'])
+                            delete_config(jazz_username, jazz_password, jazz_apiendpoint, query_url)
     else:
         print("Job Execution Failed")
 

--- a/features/utils/api_config.py
+++ b/features/utils/api_config.py
@@ -32,3 +32,9 @@ def update_config_in(key, value, username, password, endpoint, query_url):
     config_data[key] = value
     requests.post(endpoint+'/jazz/admin/config'+query_url, data=json.dumps(config_data),
                   headers={"Content-Type": "application/json", "Authorization": "%s" % (token)})
+
+
+def delete_config(username, password, endpoint, query_url):
+    token = obtain_token(username, password, endpoint)
+    requests.delete(endpoint+'/jazz/admin/config'+query_url,
+                    headers={"Content-Type": "application/json", "Authorization": "%s" % (token)})


### PR DESCRIPTION
**Description**

Uninstall does not delete the account information from config. Handle uninstall for both primary and secondary accounts based on the account user input.