### PR TITLE
API cloudwatch log role fix

### DIFF
--- a/installer/terraform/api-gateway.tf
+++ b/installer/terraform/api-gateway.tf
@@ -100,4 +100,5 @@ resource "aws_cloudwatch_log_subscription_filter" "logfilter-prod" {
 
 resource "aws_api_gateway_account" "cloudwatchlogroleupdate" {
   cloudwatch_role_arn = "${aws_iam_role.platform_role.arn}"
+  depends_on = ["aws_iam_role_policy_attachment.pushtocloudwatchlogs"]
 }


### PR DESCRIPTION
### Issue

> aws_api_gateway_account.cloudwatchlogroleupdate: 1 error(s) occurred:
> 
> * aws_api_gateway_account.cloudwatchlogroleupdate: Updating API Gateway Account failed: BadRequestException: The role ARN does not have required permissions configured. Please grant trust permission for API Gateway and add the required role policy.

### Fix

Attach the "AmazonAPIGatewayPushToCloudWatchLogs" before the cloudwatchlogroleupdate. So added a dependency in the terraform resource.
